### PR TITLE
Parse PV even after "bestmove" has been received

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -18,9 +18,7 @@ function updateInfo(game, color) {
   updateElText($(`#${color}-depth`), game[color].depth);
   updateElText($(`#${color}-nodes`), (game[color].nodes / 1000000).toFixed(2) + 'm');
   updateElText($(`#${color}-nps`), (game[color].nodes / game[color].usedTime / 1000).toFixed(2) + 'm');
-
-  // Only update PV if its STM
-  if (color.startsWith(game.stm)) $(`#${color}-pv`).html(pv(game, color));
+  $(`#${color}-pv`).html(pv(game, color));
 }
 
 function update(data, board) {

--- a/public/js/pv.js
+++ b/public/js/pv.js
@@ -1,12 +1,10 @@
 export function pv(game, color) {
-  const { moveNumber } = game;
-
+  const { pvMoveNumber: n, pv } = game[color];
   const printOn = color == 'white' ? 0 : 1;
-  const html = game[color].pv.reduce((h, move, idx) => {
-    if (idx % 2 == printOn) h += `<strong>${moveNumber + Math.floor(idx / 2) + 1}</strong>. `;
+
+  return pv.reduce((h, move, idx) => {
+    if (idx % 2 == printOn) h += `<strong>${n + Math.floor((idx + printOn) / 2)}</strong>. `;
 
     return h + `${move} `;
-  }, '');
-
-  return color == 'white' ? html : `<strong>${moveNumber}...</strong> ` + html;
+  }, color == 'white' ? '' : `<strong>${n}...</strong> `);
 }

--- a/src/chess-game.ts
+++ b/src/chess-game.ts
@@ -21,6 +21,7 @@ export type SerializedPlayer = {
   startTime: number;
   lastMove: Move | null;
   pv: Array<string>;
+  pvMoveNumber: number;
 };
 
 export class ChessGame {
@@ -144,6 +145,7 @@ export class Player {
   private _startTime: number;
   private _lastMove: Move | null;
   private _pv: Array<string>; // san representation
+  private _pvMoveNumber: number;
 
   constructor() {
     this._name = 'Unknown';
@@ -155,6 +157,7 @@ export class Player {
     this._startTime = 0;
     this._lastMove = null;
     this._pv = new Array<string>();
+    this._pvMoveNumber = 0;
   }
 
   reset(): void {
@@ -167,6 +170,7 @@ export class Player {
     this._startTime = 0;
     this._lastMove = null;
     this._pv = new Array<string>();
+    this._pvMoveNumber = 0;
   }
 
   toJSON(): SerializedPlayer {
@@ -180,6 +184,7 @@ export class Player {
       startTime: this._startTime,
       lastMove: this._lastMove,
       pv: this._pv,
+      pvMoveNumber: this._pvMoveNumber,
     };
   }
 
@@ -253,5 +258,13 @@ export class Player {
 
   public set pv(v: Array<string>) {
     this._pv = v;
+  }
+
+  public get pvMoveNumber(): number {
+    return this._pvMoveNumber;
+  }
+
+  public set pvMoveNumber(v: number) {
+    this._pvMoveNumber = v;
   }
 }


### PR DESCRIPTION
Fixes #9. 

Issue was the result of the bestmove being received before the final PV. This would cause the PV to no longer be parseable. This is resolved by making a PGN copy of the board, and undoing the last move if the PV is for the wrong side. 

Along with this, a single move number was being stored which caused PV updates after a move was made to report the wrong move number. These values are now tracked on a per-color basis to prevent this issue as well.