### PR TITLE
Add menu items

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -22,7 +22,7 @@ function updateInfo(game, color) {
 }
 
 function update(data, board) {
-  const { game, spectators, chat } = data;
+  const { game, spectators, chat, menu } = data;
 
   updateInfo(game, 'white');
   updateInfo(game, 'black');
@@ -43,6 +43,39 @@ function update(data, board) {
   chat.forEach((msg) => {
     $('#chat-box').append($('<p>').text(msg));
   });
+
+  const $eventThreadButton = $('#event-thread');
+  const $scheduleButton = $('#schedule');
+
+  if (menu.schedule) {
+    if (!$scheduleButton[0])
+      $('#button-container').append(
+        $('<a>')
+          .attr('href', menu.schedule)
+          .attr('class', 'primary button')
+          .attr('id', 'schedule')
+          .attr('target', '_blank')
+          .text('Schedule'),
+      );
+    else if ($scheduleButton.attr('href') != menu.schedule) $scheduleButton.attr('href', menu.schedule);
+  } else {
+    $scheduleButton.remove();
+  }
+
+  if (menu.even) {
+    if (!$eventThreadButton[0])
+      $('#button-container').append(
+        $('<a>')
+          .attr('href', menu.even)
+          .attr('class', 'primary button')
+          .attr('id', 'event-thread')
+          .attr('target', '_blank')
+          .text('Event'),
+      );
+    else if ($eventThreadButton.attr('href') != menu.even) $eventThreadButton.attr('href', menu.even);
+  } else {
+    $eventThreadButton.remove();
+  }
 }
 
 function chatHeight() {

--- a/src/broadcast.ts
+++ b/src/broadcast.ts
@@ -11,6 +11,7 @@ export type SerializedBroadcast = {
   spectators: Array<string>;
   browserCount: number;
   chat: Array<string>;
+  menu: { [key: string]: string };
 };
 
 export class Broadcast {
@@ -20,6 +21,7 @@ export class Broadcast {
   private _browserCount: number;
   private _spectators: Set<string>;
   private _chat: Array<string>;
+  private _menu: Map<string, string>;
   private _game: ChessGame;
   private _handler: Handler;
   private _connection: Connection;
@@ -40,6 +42,7 @@ export class Broadcast {
     this._results = '';
     this._spectators = new Set();
     this._chat = [];
+    this._menu = new Map<string, string>();
   }
 
   loadResults(): Promise<string> {
@@ -74,11 +77,15 @@ export class Broadcast {
   }
 
   toJSON(): SerializedBroadcast {
+    const menu: { [key: string]: string } = {};
+    for (const e of this._menu.entries()) menu[e[0]] = e[1];
+
     return {
       game: this.game.toJSON(),
       spectators: Array.from(this._spectators),
       browserCount: this._browserCount,
       chat: this._chat.slice(-100),
+      menu,
     };
   }
 
@@ -112,6 +119,10 @@ export class Broadcast {
 
   public set browserCount(v: number) {
     this._browserCount = v;
+  }
+
+  public get menu(): Map<string, string> {
+    return this._menu;
   }
 }
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -23,6 +23,7 @@ export enum Command {
   ADDUSER = 'ADDUSER',
   DELUSER = 'DELUSER',
   CHAT = 'CHAT',
+  MENU = 'MENU',
 }
 
 type ConfigItem = {
@@ -62,6 +63,7 @@ class Handler {
       [Command.ADDUSER]: { fn: this.onAddUser.bind(this), split: false },
       [Command.DELUSER]: { fn: this.onDelUser.bind(this), split: false },
       [Command.CHAT]: { fn: this.onChat.bind(this), split: false },
+      [Command.MENU]: { fn: this.onMenu.bind(this), split: true },
     };
   }
 
@@ -220,6 +222,26 @@ class Handler {
   private onChat(tokens: CommandTokens): boolean {
     this._broadcast.chat.push(tokens[1]);
 
+    return true;
+  }
+
+  private onMenu(tokens: CommandTokens): boolean {
+    let nameIdx = -1;
+    let valueIdx = -1;
+
+    tokens.forEach((v, i) => {
+      if (v.startsWith('NAME=')) nameIdx = i;
+      if (v.startsWith('URL=')) valueIdx = i;
+    });
+
+    if (nameIdx == -1 || valueIdx == -1) return false;
+
+    const name = tokens[nameIdx].slice(6, -1).toLowerCase(); // chop NAME="
+    const url = tokens[valueIdx].slice(5, -1); // chop URL="
+
+    this._broadcast.menu.set(name, url);
+
+    logger.info(`Updated broadcast ${this._broadcast.port} Menu - Name: ${name}, Value: ${url}`);
     return true;
   }
 

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -1,7 +1,7 @@
 import { Command } from '../handler';
 
 export function splitOnCommand(line: string): [Command, string] {
-  const argSplit = line.indexOf(':');
+  const argSplit = Math.min(line.indexOf(':'), line.indexOf(' '));
 
   if (argSplit < 0) return [line as Command, ''];
 


### PR DESCRIPTION
Support the TLCS command of MENU.

Example: `< 24871>MENU ID=2 WIDTH=12000 HEIGHT=6000 NAME="Schedule" URL="http://kirill-kryukov.com/chess/discussion-board/viewtopic.php?f=7&t=13246#p122060"`

Parses this into a broadcast map as `{ schedule: 'http://...' }`. UI is designed specifically to look for `schedule` and `even`, and display links to those URLs.