### PR TITLE
Lazy regex for name in chat detection

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -106,7 +106,7 @@ function addChat(msg) {
       [, , , rest] = res;
     }
   } else {
-    const res = /\[(.*)\]\s+-\s+(.*)/i.exec(msg);
+    const res = /\[(.*?)\]\s+-\s+(.*)/i.exec(msg);
     if (res) {
       name = `[${res[1]}] `;
       [, , rest] = res;


### PR DESCRIPTION
This handles the case where an engine has [] in their name.

In particular SoFCheck [v0.9.1-beta amd64-bmi2]