### PR TITLE
Fixed or reduced doubled king issue in PV boards

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -144,8 +144,8 @@ function update(data, board, pvBoardWhite, pvBoardBlack) {
 
   $('#fen').text(game.fen);
   board.position(game.fen);
-  pvBoardWhite.position(game.white.pvFen);
-  pvBoardBlack.position(game.black.pvFen);
+  pvBoardWhite.position(game.white.pvFen, false);
+  pvBoardBlack.position(game.black.pvFen, false);
 
   clearArrows();
 
@@ -214,9 +214,6 @@ $(() => {
   const pvBoardSettings = {
     pieceTheme: '/img/{piece}.svg',
     showNotation: false,
-    appearSpeed: 0,
-    moveSpeed: 0,
-    trashSpeed: 0,
   };
   const pvBoardWhite = Chessboard('white-pv-board', pvBoardSettings);
   const pvBoardBlack = Chessboard('black-pv-board', pvBoardSettings);


### PR DESCRIPTION
I didn't test it very extensively, but it seems to at least reduce the frequency that it happens (haven't noticed it once while watching one game).

The issue was probably that initially I “removed” the animations by setting the animation times to zero, instead of using the animation flag in [.position(newPosition, useAnimation)](https://chessboardjs.com/docs.html#methods:position).

Would close  #84.