### PR TITLE
Allow fetching active broadcast IDs via /broadcasts

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -13,6 +13,12 @@ router.get('/', (_: Request, res: Response): void => {
   res.redirect(`/${first.port}`);
 });
 
+router.get('/broadcasts', (_: Request, res: Response): void => {
+  const broadcast_ids = broadcasts.keys();
+
+  res.status(200).contentType('application/json').send(JSON.stringify(broadcast_ids));
+});
+
 router.use('/:port([0-9]+)', (req: Request, res: Response, next: NextFunction): void => {
   const port: number = parseInt(req.params.port);
   const broadcast: Broadcast | undefined = broadcasts.get(port);


### PR DESCRIPTION
I've been working on https://github.com/jgilchrist/ccrl-live-notifier as a fairly low-tech solution to send Discord notifications that mention engine authors (or other interested parties) when their engines start playing games (https://github.com/jhonnold/node-tlcv/issues/57 / https://github.com/jhonnold/node-tlcv/issues/56).

It's working - however, the list of broadcasts to check currently needs to be hardcoded in the config: https://github.com/jgilchrist/ccrl-live-notifier/blob/master/config.json#L2.

More ideal would be to be able to grab the list of active broadcasts so there's no need to actively maintain the list. If there's any appetite for that, in theory this change would allow it.
