### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/docs/plans/2026-04-04-prometheus-metrics-design.md
+++ b/docs/plans/2026-04-04-prometheus-metrics-design.md
@@ -1,0 +1,91 @@
+# Prometheus Metrics Endpoint Design
+
+## Overview
+
+Add a `/admin/metrics` endpoint for Prometheus pull-based collection, providing both operational health and usage insights for the CCRL live chess broadcast service.
+
+## Decisions
+
+- **Library:** `prom-client` (standard Node.js Prometheus client)
+- **Prefix:** `ccrl_` (matches production domain ccrl.live)
+- **Approach:** Centralized metrics module (`src/metrics.ts`) with counters instrumented at call sites
+- **Route:** `GET /admin/metrics` behind existing basic auth in `src/routes/admin.ts`
+- **Default process metrics:** Enabled (`ccrl_process_*`, `ccrl_nodejs_*`)
+- **Privacy:** No PII — no usernames, IPs, locations, or chat message content in any metric or label
+
+## Metric Definitions
+
+### Gauges (collected at scrape time via `collect()` callbacks)
+
+| Metric | Labels | Source |
+|--------|--------|--------|
+| `ccrl_broadcasts_active` | — | `broadcasts.size` |
+| `ccrl_broadcast_spectators` | `port`, `event` | `broadcast.spectators.size` |
+| `ccrl_broadcast_browser_connections` | `port`, `event` | `broadcast.browserCount` |
+| `ccrl_kibitzer_total` | — | count of kibitzer entries |
+| `ccrl_kibitzer_ready` | `id`, `engine`, `type` | `status.ready` (1/0) |
+| `ccrl_kibitzer_target_port` | `id`, `engine`, `type` | `status.targetPort` (0 if unassigned) |
+| `ccrl_game_move_number` | `port`, `event` | `game.moveMeta.length` |
+
+### Counters (instrumented at call sites)
+
+| Metric | Labels | Increment Location |
+|--------|--------|--------------------|
+| `ccrl_udp_messages_received_total` | `port`, `event` | `udp-transport.ts` on message receive |
+| `ccrl_udp_messages_out_of_order_total` | `port`, `event` | `udp-transport.ts` on sequence violation |
+| `ccrl_commands_processed_total` | `port`, `event`, `command` | `game-service.ts` in `onMessages()` |
+| `ccrl_chat_messages_total` | `port`, `event` | `game-service.ts` on CHAT command |
+| `ccrl_spectator_joins_total` | `port`, `event` | `socket-io-adapter.ts` on join |
+| `ccrl_spectator_leaves_total` | `port`, `event` | `socket-io-adapter.ts` on disconnect |
+| `ccrl_socket_emissions_total` | `port`, `event`, `type` | `socket-io-adapter.ts` on emitUpdate/emitChat |
+| `ccrl_kibitzer_assignments_total` | `id` | `kibitzer-manager.ts` on reassignment |
+| `ccrl_message_buffer_errors_total` | `port` | `message-buffer.ts` on processing error |
+
+### Default Process Metrics
+
+Enabled via `collectDefaultMetrics({ prefix: 'ccrl_' })`:
+- `ccrl_process_cpu_seconds_total`, `ccrl_process_resident_memory_bytes`
+- `ccrl_nodejs_eventloop_lag_seconds`, `ccrl_nodejs_heap_size_*_bytes`
+- `ccrl_nodejs_active_handles_total`, etc.
+
+## Architecture
+
+### New Files
+
+- `src/metrics.ts` — All metric definitions, gauge `collect()` callbacks, counter exports
+
+### Modified Files
+
+- `src/routes/admin.ts` — Add `GET /metrics` route, calls `register.metrics()`
+- `src/transport/udp-transport.ts` — Increment `ccrl_udp_messages_received_total`, `ccrl_udp_messages_out_of_order_total`
+- `src/game-service.ts` — Increment `ccrl_commands_processed_total`, `ccrl_chat_messages_total`
+- `src/socket-io-adapter.ts` — Increment `ccrl_spectator_joins_total`, `ccrl_spectator_leaves_total`, `ccrl_socket_emissions_total`
+- `src/kibitzer/kibitzer-manager.ts` — Increment `ccrl_kibitzer_assignments_total`
+- `src/transport/message-buffer.ts` — Increment `ccrl_message_buffer_errors_total`
+- `package.json` — Add `prom-client` dependency
+
+### Data Flow
+
+```
+Prometheus scraper
+  → GET /admin/metrics (basic auth: admin / TLCV_PASSWORD)
+  → Express route in admin.ts
+  → prom-client register.metrics()
+  → collect() callbacks read broadcasts Map + KibitzerManager.getStatus()
+  → Returns text/plain OpenMetrics format
+```
+
+### Label Resolution
+
+Counter call sites resolve `event` from `broadcasts.get(port)?.game.site ?? 'unknown'`. The `broadcasts` Map is already imported as a global in these files.
+
+### Prometheus Scrape Config (reference)
+
+```yaml
+scrape_configs:
+  - job_name: ccrl
+    metrics_path: /admin/metrics
+    basic_auth:
+      username: admin
+      password: <TLCV_PASSWORD>
+```

--- a/docs/plans/2026-04-04-prometheus-metrics-plan.md
+++ b/docs/plans/2026-04-04-prometheus-metrics-plan.md
@@ -1,0 +1,485 @@
+# Prometheus Metrics Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `/admin/metrics` Prometheus endpoint exposing operational and usage metrics for the CCRL broadcast service.
+
+**Architecture:** Centralized `src/metrics.ts` module defines all metrics (gauges with `collect()` callbacks, counters exported for call-site instrumentation). Route in `src/routes/admin.ts` behind existing basic auth. `prom-client` library with default Node.js process metrics enabled.
+
+**Tech Stack:** `prom-client` (Prometheus client for Node.js), Express, TypeScript ESM
+
+---
+
+### Task 1: Install prom-client
+
+**Files:**
+- Modify: `package.json`
+
+**Step 1: Install the dependency**
+
+Run: `npm install prom-client`
+
+**Step 2: Verify installation**
+
+Run: `node -e "import('prom-client').then(m => console.log(Object.keys(m.default || m).slice(0,5)))"`
+Expected: Array of exported names like `['Counter', 'Gauge', 'Histogram', ...]`
+
+**Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "deps: add prom-client for Prometheus metrics"
+```
+
+---
+
+### Task 2: Create centralized metrics module
+
+**Files:**
+- Create: `src/metrics.ts`
+
+**Step 1: Create the metrics module**
+
+```typescript
+import { Counter, Gauge, Registry, collectDefaultMetrics } from 'prom-client';
+import broadcasts from './broadcast.js';
+import { getKibitzerManager } from './broadcast-manager.js';
+
+export const register = new Registry();
+
+collectDefaultMetrics({ register, prefix: 'ccrl_' });
+
+// --- Gauges (collected at scrape time) ---
+
+export const broadcastsActive = new Gauge({
+  name: 'ccrl_broadcasts_active',
+  help: 'Number of currently active broadcasts',
+  registers: [register],
+  collect() {
+    this.set(broadcasts.size);
+  },
+});
+
+export const broadcastSpectators = new Gauge({
+  name: 'ccrl_broadcast_spectators',
+  help: 'Current spectator count per broadcast',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+  collect() {
+    this.reset();
+    for (const [port, broadcast] of broadcasts) {
+      this.set({ port: String(port), event: broadcast.game.site ?? 'unknown' }, broadcast.spectators.size);
+    }
+  },
+});
+
+export const broadcastBrowserConnections = new Gauge({
+  name: 'ccrl_broadcast_browser_connections',
+  help: 'Current browser connection count per broadcast',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+  collect() {
+    this.reset();
+    for (const [port, broadcast] of broadcasts) {
+      this.set({ port: String(port), event: broadcast.game.site ?? 'unknown' }, broadcast.browserCount);
+    }
+  },
+});
+
+export const gameMoveNumber = new Gauge({
+  name: 'ccrl_game_move_number',
+  help: 'Current move number in the active game per broadcast',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+  collect() {
+    this.reset();
+    for (const [port, broadcast] of broadcasts) {
+      this.set({ port: String(port), event: broadcast.game.site ?? 'unknown' }, broadcast.game.moveMeta.length);
+    }
+  },
+});
+
+export const kibitzerTotal = new Gauge({
+  name: 'ccrl_kibitzer_total',
+  help: 'Total number of configured kibitzer transports',
+  registers: [register],
+  collect() {
+    const statuses = getKibitzerManager()?.getStatus() ?? [];
+    this.set(statuses.length);
+  },
+});
+
+export const kibitzerReady = new Gauge({
+  name: 'ccrl_kibitzer_ready',
+  help: 'Whether a kibitzer transport is ready (1) or not (0)',
+  labelNames: ['id', 'engine', 'type'] as const,
+  registers: [register],
+  collect() {
+    this.reset();
+    const statuses = getKibitzerManager()?.getStatus() ?? [];
+    for (const s of statuses) {
+      this.set({ id: s.id, engine: s.engineName || 'unknown', type: s.type }, s.ready ? 1 : 0);
+    }
+  },
+});
+
+export const kibitzerTargetPort = new Gauge({
+  name: 'ccrl_kibitzer_target_port',
+  help: 'Port number the kibitzer is currently analyzing (0 if unassigned)',
+  labelNames: ['id', 'engine', 'type'] as const,
+  registers: [register],
+  collect() {
+    this.reset();
+    const statuses = getKibitzerManager()?.getStatus() ?? [];
+    for (const s of statuses) {
+      this.set({ id: s.id, engine: s.engineName || 'unknown', type: s.type }, s.targetPort ?? 0);
+    }
+  },
+});
+
+// --- Counters (incremented at call sites) ---
+
+export const udpMessagesReceived = new Counter({
+  name: 'ccrl_udp_messages_received_total',
+  help: 'Total UDP messages received',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+});
+
+export const udpMessagesOutOfOrder = new Counter({
+  name: 'ccrl_udp_messages_out_of_order_total',
+  help: 'Total UDP messages received out of order and skipped',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+});
+
+export const commandsProcessed = new Counter({
+  name: 'ccrl_commands_processed_total',
+  help: 'Total commands processed by game service',
+  labelNames: ['port', 'event', 'command'] as const,
+  registers: [register],
+});
+
+export const chatMessages = new Counter({
+  name: 'ccrl_chat_messages_total',
+  help: 'Total chat messages received from the chess server',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+});
+
+export const spectatorJoins = new Counter({
+  name: 'ccrl_spectator_joins_total',
+  help: 'Total spectator joins via Socket.IO',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+});
+
+export const spectatorLeaves = new Counter({
+  name: 'ccrl_spectator_leaves_total',
+  help: 'Total spectator disconnects via Socket.IO',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+});
+
+export const socketEmissions = new Counter({
+  name: 'ccrl_socket_emissions_total',
+  help: 'Total Socket.IO emissions to clients',
+  labelNames: ['port', 'event', 'type'] as const,
+  registers: [register],
+});
+
+export const kibitzerAssignments = new Counter({
+  name: 'ccrl_kibitzer_assignments_total',
+  help: 'Total kibitzer transport reassignments',
+  labelNames: ['id'] as const,
+  registers: [register],
+});
+
+export const messageBufferErrors = new Counter({
+  name: 'ccrl_message_buffer_errors_total',
+  help: 'Total errors during message buffer processing',
+  labelNames: ['port'] as const,
+  registers: [register],
+});
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc -p tsconfig.backend.json --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/metrics.ts
+git commit -m "feat(metrics): add centralized Prometheus metrics module"
+```
+
+---
+
+### Task 3: Add /admin/metrics route
+
+**Files:**
+- Modify: `src/routes/admin.ts:1-10` (add import), append route before export
+
+**Step 1: Add the route**
+
+Add import at top of `src/routes/admin.ts`:
+
+```typescript
+import { register } from '../metrics.js';
+```
+
+Add route before `export default router;` (before line 118):
+
+```typescript
+router.get('/metrics', async (_: Request, res: Response) => {
+  res.set('Content-Type', register.contentType);
+  res.end(await register.metrics());
+});
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc -p tsconfig.backend.json --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/routes/admin.ts
+git commit -m "feat(metrics): add GET /admin/metrics route"
+```
+
+---
+
+### Task 4: Instrument UDP transport counters
+
+**Files:**
+- Modify: `src/transport/udp-transport.ts`
+
+**Step 1: Add counter increments**
+
+Add import at top:
+
+```typescript
+import broadcasts from '../broadcast.js';
+import { udpMessagesReceived, udpMessagesOutOfOrder } from '../metrics.js';
+```
+
+In the `onMessage` method, after the existing `logger.debug` on line 44 (before `const fullMessage`), add:
+
+```typescript
+const event = broadcasts.get(this.port)?.game.site ?? 'unknown';
+udpMessagesReceived.inc({ port: String(this.port), event });
+```
+
+In the out-of-order branch (line 57-61), before the `return` on line 61, add:
+
+```typescript
+udpMessagesOutOfOrder.inc({ port: String(this.port), event });
+```
+
+Note: The `event` variable is declared before the out-of-order check, so it's available in scope.
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc -p tsconfig.backend.json --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/transport/udp-transport.ts
+git commit -m "feat(metrics): instrument UDP transport message counters"
+```
+
+---
+
+### Task 5: Instrument game service counters
+
+**Files:**
+- Modify: `src/game-service.ts`
+
+**Step 1: Add counter increments**
+
+Add import at top (after existing imports):
+
+```typescript
+import { commandsProcessed, chatMessages } from './metrics.js';
+```
+
+In `onMessages()` method (line 519), inside the `for` loop (line 532), after the line that calls `commandConfig.fn(...)` (line 535-537), add:
+
+```typescript
+const event = this.broadcast.game.site ?? 'unknown';
+commandsProcessed.inc({ port: String(this.broadcast.port), event, command: cmd });
+```
+
+In the `onChat` method (line 377), at the start of the method before the connection message filter (line 379), add:
+
+```typescript
+chatMessages.inc({ port: String(this.broadcast.port), event: this.game.site ?? 'unknown' });
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc -p tsconfig.backend.json --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/game-service.ts
+git commit -m "feat(metrics): instrument game service command and chat counters"
+```
+
+---
+
+### Task 6: Instrument Socket.IO adapter counters
+
+**Files:**
+- Modify: `src/socket-io-adapter.ts`
+
+**Step 1: Add counter increments**
+
+Add import at top:
+
+```typescript
+import { spectatorJoins, spectatorLeaves, socketEmissions } from './metrics.js';
+```
+
+In the `join` handler (line 19), after `broadcast.browserCount++` (line 23), add:
+
+```typescript
+const event = broadcast.game.site ?? 'unknown';
+spectatorJoins.inc({ port: String(port), event });
+```
+
+In the `disconnect` handler (line 52), after `broadcast.browserCount--` (line 55), add:
+
+```typescript
+const event = broadcast.game.site ?? 'unknown';
+spectatorLeaves.inc({ port: String(port), event });
+```
+
+In `emitUpdate` function (line 63), add before the `io.to(...)` call:
+
+```typescript
+const event = broadcasts.get(port)?.game.site ?? 'unknown';
+socketEmissions.inc({ port: String(port), event, type: 'update' });
+```
+
+In `emitChat` function (line 67), add before the `io.to(...)` call:
+
+```typescript
+const event = broadcasts.get(port)?.game.site ?? 'unknown';
+socketEmissions.inc({ port: String(port), event, type: 'chat' });
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc -p tsconfig.backend.json --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/socket-io-adapter.ts
+git commit -m "feat(metrics): instrument Socket.IO spectator and emission counters"
+```
+
+---
+
+### Task 7: Instrument kibitzer assignment counter
+
+**Files:**
+- Modify: `src/kibitzer/kibitzer-manager.ts`
+
+**Step 1: Add counter increments**
+
+Add import at top:
+
+```typescript
+import { kibitzerAssignments } from '../metrics.js';
+```
+
+In the `startSlot` method (line 270), after `this.slots.set(port, slot)` (line 286), add:
+
+```typescript
+const entry = this.transports.find((e) => e.transport === transport);
+if (entry) kibitzerAssignments.inc({ id: entry.id });
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc -p tsconfig.backend.json --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/kibitzer/kibitzer-manager.ts
+git commit -m "feat(metrics): instrument kibitzer assignment counter"
+```
+
+---
+
+### Task 8: Instrument message buffer error counter
+
+**Files:**
+- Modify: `src/transport/message-buffer.ts`
+
+**Step 1: Add counter increments**
+
+Add import at top:
+
+```typescript
+import { messageBufferErrors } from '../metrics.js';
+```
+
+In the `drain` method, inside the `catch` block (line 39-40), after the `logger.error` call, add:
+
+```typescript
+messageBufferErrors.inc({ port: String(this.port) });
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc -p tsconfig.backend.json --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/transport/message-buffer.ts
+git commit -m "feat(metrics): instrument message buffer error counter"
+```
+
+---
+
+### Task 9: Full build verification
+
+**Step 1: Run full build (TypeScript + webpack)**
+
+Run: `npm run build`
+Expected: Clean build with no errors
+
+**Step 2: Verify metrics module is in build output**
+
+Run: `ls build/src/metrics.js`
+Expected: File exists
+
+**Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: No errors (auto-fix may adjust formatting)
+
+**Step 4: Commit any lint fixes**
+
+```bash
+git add -A
+git commit -m "style: apply lint fixes for metrics instrumentation"
+```
+
+(Skip this commit if lint made no changes.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "mini.css": "^3.0.1",
         "mkdirp": "^3.0.1",
         "on-finished": "^2.3.0",
+        "prom-client": "^15.1.3",
         "reset-css": "^5.0.1",
         "serve-index": "^1.9.1",
         "slugify": "^1.6.6",
@@ -473,6 +474,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -2164,6 +2174,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -8049,6 +8065,19 @@
         "renderkid": "^3.0.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -9674,6 +9703,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/terser": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "mini.css": "^3.0.1",
     "mkdirp": "^3.0.1",
     "on-finished": "^2.3.0",
+    "prom-client": "^15.1.3",
     "reset-css": "^5.0.1",
     "serve-index": "^1.9.1",
     "slugify": "^1.6.6",

--- a/src/game-service.ts
+++ b/src/game-service.ts
@@ -8,6 +8,7 @@ import { saveGameMeta, invalidate as invalidateMetaCache } from './services/game
 import { invalidate as invalidatePgnCache } from './services/pgn-cache.js';
 import { Command, splitOnCommand } from './protocol.js';
 import { EmitType } from './socket-io-adapter.js';
+import { commandsProcessed, chatMessages } from './metrics.js';
 import { parseResults, parseGames } from './services/result-parser.js';
 import type { BroadcastDelta, ColorCode, GameDelta } from '../shared/types.js';
 
@@ -375,6 +376,7 @@ class GameService {
   }
 
   private onChat(tokens: CommandTokens): UpdateResult {
+    chatMessages.inc({ port: String(this.broadcast.port), event: this.game.site ?? 'unknown' });
     // Disable connection messages. TODO: Make this configurable
     if (tokens[1].endsWith('has arrived!') || tokens[1].endsWith('has left!')) return [EmitType.CHAT, false];
 
@@ -535,6 +537,12 @@ class GameService {
       const [emit, updated, ...updateData] = await commandConfig.fn(
         commandConfig.split ? [cmd, ...rest.trim().split(/\s+/)] : [cmd, rest],
       );
+
+      commandsProcessed.inc({
+        port: String(this.broadcast.port),
+        event: this.broadcast.game.site ?? 'unknown',
+        command: cmd,
+      });
 
       if (updated && emit === EmitType.CHAT) {
         chatEmit.push(updateData[0]);

--- a/src/game-service.ts
+++ b/src/game-service.ts
@@ -376,7 +376,7 @@ class GameService {
   }
 
   private onChat(tokens: CommandTokens): UpdateResult {
-    chatMessages.inc({ port: String(this.broadcast.port), event: this.game.site ?? 'unknown' });
+    chatMessages.inc({ port: String(this.broadcast.port) });
     // Disable connection messages. TODO: Make this configurable
     if (tokens[1].endsWith('has arrived!') || tokens[1].endsWith('has left!')) return [EmitType.CHAT, false];
 
@@ -538,11 +538,7 @@ class GameService {
         commandConfig.split ? [cmd, ...rest.trim().split(/\s+/)] : [cmd, rest],
       );
 
-      commandsProcessed.inc({
-        port: String(this.broadcast.port),
-        event: this.broadcast.game.site ?? 'unknown',
-        command: cmd,
-      });
+      commandsProcessed.inc({ port: String(this.broadcast.port), command: cmd });
 
       if (updated && emit === EmitType.CHAT) {
         chatEmit.push(updateData[0]);

--- a/src/kibitzer/kibitzer-manager.ts
+++ b/src/kibitzer/kibitzer-manager.ts
@@ -1,6 +1,7 @@
 import { Chess } from 'chess.js';
 import broadcasts from '../broadcast.js';
 import { emitUpdate } from '../socket-io-adapter.js';
+import { kibitzerAssignments } from '../metrics.js';
 import { logger } from '../util/index.js';
 import { createTransport } from './transport-factory.js';
 import type { KibitzerTransport, KibitzerConfig, AnalysisInfo } from './types.js';
@@ -284,6 +285,9 @@ export class KibitzerManager {
     });
 
     this.slots.set(port, slot);
+
+    const entry = this.transports.find((e) => e.transport === transport);
+    if (entry) kibitzerAssignments.inc({ id: entry.id });
 
     const fen = broadcast.game.instance.fen();
     slot.currentFen = fen;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -140,7 +140,7 @@ export const spectatorLeaves = new Counter({
 
 export const socketEmissions = new Counter({
   name: 'ccrl_socket_emissions_total',
-  help: 'Total Socket.IO emissions to clients',
+  help: 'Total Socket.IO broadcast emission events',
   labelNames: ['port', 'event', 'type'] as const,
   registers: [register],
 });

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -99,49 +99,49 @@ export const kibitzerTargetPort = new Gauge({
 export const udpMessagesReceived = new Counter({
   name: 'ccrl_udp_messages_received_total',
   help: 'Total UDP messages received',
-  labelNames: ['port', 'event'] as const,
+  labelNames: ['port'] as const,
   registers: [register],
 });
 
 export const udpMessagesOutOfOrder = new Counter({
   name: 'ccrl_udp_messages_out_of_order_total',
   help: 'Total UDP messages received out of order and skipped',
-  labelNames: ['port', 'event'] as const,
+  labelNames: ['port'] as const,
   registers: [register],
 });
 
 export const commandsProcessed = new Counter({
   name: 'ccrl_commands_processed_total',
   help: 'Total commands processed by game service',
-  labelNames: ['port', 'event', 'command'] as const,
+  labelNames: ['port', 'command'] as const,
   registers: [register],
 });
 
 export const chatMessages = new Counter({
   name: 'ccrl_chat_messages_total',
   help: 'Total chat messages received from the chess server',
-  labelNames: ['port', 'event'] as const,
+  labelNames: ['port'] as const,
   registers: [register],
 });
 
 export const spectatorJoins = new Counter({
   name: 'ccrl_spectator_joins_total',
   help: 'Total spectator joins via Socket.IO',
-  labelNames: ['port', 'event'] as const,
+  labelNames: ['port'] as const,
   registers: [register],
 });
 
 export const spectatorLeaves = new Counter({
   name: 'ccrl_spectator_leaves_total',
   help: 'Total spectator disconnects via Socket.IO',
-  labelNames: ['port', 'event'] as const,
+  labelNames: ['port'] as const,
   registers: [register],
 });
 
 export const socketEmissions = new Counter({
   name: 'ccrl_socket_emissions_total',
   help: 'Total Socket.IO broadcast emission events',
-  labelNames: ['port', 'event', 'type'] as const,
+  labelNames: ['port', 'type'] as const,
   registers: [register],
 });
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,160 @@
+import { Counter, Gauge, Registry, collectDefaultMetrics } from 'prom-client';
+import broadcasts from './broadcast.js';
+import { getKibitzerManager } from './broadcast-manager.js';
+
+export const register = new Registry();
+
+collectDefaultMetrics({ register, prefix: 'ccrl_' });
+
+// --- Gauges (collected at scrape time) ---
+
+export const broadcastsActive = new Gauge({
+  name: 'ccrl_broadcasts_active',
+  help: 'Number of currently active broadcasts',
+  registers: [register],
+  collect() {
+    this.set(broadcasts.size);
+  },
+});
+
+export const broadcastSpectators = new Gauge({
+  name: 'ccrl_broadcast_spectators',
+  help: 'Current spectator count per broadcast',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+  collect() {
+    this.reset();
+    for (const [port, broadcast] of broadcasts) {
+      this.set({ port: String(port), event: broadcast.game.site ?? 'unknown' }, broadcast.spectators.size);
+    }
+  },
+});
+
+export const broadcastBrowserConnections = new Gauge({
+  name: 'ccrl_broadcast_browser_connections',
+  help: 'Current browser connection count per broadcast',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+  collect() {
+    this.reset();
+    for (const [port, broadcast] of broadcasts) {
+      this.set({ port: String(port), event: broadcast.game.site ?? 'unknown' }, broadcast.browserCount);
+    }
+  },
+});
+
+export const gameMoveNumber = new Gauge({
+  name: 'ccrl_game_move_number',
+  help: 'Current move number in the active game per broadcast',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+  collect() {
+    this.reset();
+    for (const [port, broadcast] of broadcasts) {
+      this.set({ port: String(port), event: broadcast.game.site ?? 'unknown' }, broadcast.game.moveMeta.length);
+    }
+  },
+});
+
+export const kibitzerTotal = new Gauge({
+  name: 'ccrl_kibitzer_total',
+  help: 'Total number of configured kibitzer transports',
+  registers: [register],
+  collect() {
+    const statuses = getKibitzerManager()?.getStatus() ?? [];
+    this.set(statuses.length);
+  },
+});
+
+export const kibitzerReady = new Gauge({
+  name: 'ccrl_kibitzer_ready',
+  help: 'Whether a kibitzer transport is ready (1) or not (0)',
+  labelNames: ['id', 'engine', 'type'] as const,
+  registers: [register],
+  collect() {
+    this.reset();
+    const statuses = getKibitzerManager()?.getStatus() ?? [];
+    for (const s of statuses) {
+      this.set({ id: s.id, engine: s.engineName || 'unknown', type: s.type }, s.ready ? 1 : 0);
+    }
+  },
+});
+
+export const kibitzerTargetPort = new Gauge({
+  name: 'ccrl_kibitzer_target_port',
+  help: 'Port number the kibitzer is currently analyzing (0 if unassigned)',
+  labelNames: ['id', 'engine', 'type'] as const,
+  registers: [register],
+  collect() {
+    this.reset();
+    const statuses = getKibitzerManager()?.getStatus() ?? [];
+    for (const s of statuses) {
+      this.set({ id: s.id, engine: s.engineName || 'unknown', type: s.type }, s.targetPort ?? 0);
+    }
+  },
+});
+
+// --- Counters (incremented at call sites) ---
+
+export const udpMessagesReceived = new Counter({
+  name: 'ccrl_udp_messages_received_total',
+  help: 'Total UDP messages received',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+});
+
+export const udpMessagesOutOfOrder = new Counter({
+  name: 'ccrl_udp_messages_out_of_order_total',
+  help: 'Total UDP messages received out of order and skipped',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+});
+
+export const commandsProcessed = new Counter({
+  name: 'ccrl_commands_processed_total',
+  help: 'Total commands processed by game service',
+  labelNames: ['port', 'event', 'command'] as const,
+  registers: [register],
+});
+
+export const chatMessages = new Counter({
+  name: 'ccrl_chat_messages_total',
+  help: 'Total chat messages received from the chess server',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+});
+
+export const spectatorJoins = new Counter({
+  name: 'ccrl_spectator_joins_total',
+  help: 'Total spectator joins via Socket.IO',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+});
+
+export const spectatorLeaves = new Counter({
+  name: 'ccrl_spectator_leaves_total',
+  help: 'Total spectator disconnects via Socket.IO',
+  labelNames: ['port', 'event'] as const,
+  registers: [register],
+});
+
+export const socketEmissions = new Counter({
+  name: 'ccrl_socket_emissions_total',
+  help: 'Total Socket.IO emissions to clients',
+  labelNames: ['port', 'event', 'type'] as const,
+  registers: [register],
+});
+
+export const kibitzerAssignments = new Counter({
+  name: 'ccrl_kibitzer_assignments_total',
+  help: 'Total kibitzer transport reassignments',
+  labelNames: ['id'] as const,
+  registers: [register],
+});
+
+export const messageBufferErrors = new Counter({
+  name: 'ccrl_message_buffer_errors_total',
+  help: 'Total errors during message buffer processing',
+  labelNames: ['port'] as const,
+  registers: [register],
+});

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -117,8 +117,13 @@ router.delete('/kibitzers/:id', async (req: Request, res: Response) => {
 });
 
 router.get('/metrics', async (_: Request, res: Response) => {
-  res.set('Content-Type', register.contentType);
-  res.end(await register.metrics());
+  try {
+    res.set('Content-Type', register.contentType);
+    res.end(await register.metrics());
+  } catch (err) {
+    logger.error(`Metrics scrape failed: ${err}`);
+    res.status(500).end();
+  }
 });
 
 export default router;

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -6,6 +6,7 @@ import { logger } from '../util/index.js';
 import { closeConnection, getKibitzerManager, newConnection } from '../broadcast-manager.js';
 import configStore from '../config/config-store.js';
 import type { KibitzerConfig } from '../kibitzer/types.js';
+import { register } from '../metrics.js';
 
 const router = Router();
 
@@ -113,6 +114,11 @@ router.delete('/kibitzers/:id', async (req: Request, res: Response) => {
     logger.error(error);
     res.sendStatus(400);
   }
+});
+
+router.get('/metrics', async (_: Request, res: Response) => {
+  res.set('Content-Type', register.contentType);
+  res.end(await register.metrics());
 });
 
 export default router;

--- a/src/socket-io-adapter.ts
+++ b/src/socket-io-adapter.ts
@@ -22,7 +22,7 @@ io.on('connection', (socket: Socket) => {
     if (!broadcast) return;
 
     broadcast.browserCount++;
-    spectatorJoins.inc({ port: String(port), event: broadcast.game.site ?? 'unknown' });
+    spectatorJoins.inc({ port: String(port) });
 
     username = uniqueName(user, broadcast.spectators);
     if (username) broadcast.spectators.add(username);
@@ -55,7 +55,7 @@ io.on('connection', (socket: Socket) => {
     if (!broadcast) return;
 
     broadcast.browserCount--;
-    spectatorLeaves.inc({ port: String(broadcast.port), event: broadcast.game.site ?? 'unknown' });
+    spectatorLeaves.inc({ port: String(broadcast.port) });
 
     if (username) broadcast.spectators.delete(username);
 
@@ -64,12 +64,12 @@ io.on('connection', (socket: Socket) => {
 });
 
 export function emitUpdate(port: number, data: BroadcastDelta): void {
-  socketEmissions.inc({ port: String(port), event: broadcasts.get(port)?.game.site ?? 'unknown', type: 'update' });
+  socketEmissions.inc({ port: String(port), type: 'update' });
   io.to(String(port)).emit(EmitType.UPDATE, data);
 }
 
 export function emitChat(port: number, messages: string[]): void {
-  socketEmissions.inc({ port: String(port), event: broadcasts.get(port)?.game.site ?? 'unknown', type: 'chat' });
+  socketEmissions.inc({ port: String(port), type: 'chat' });
   io.to(String(port)).emit(EmitType.CHAT, messages);
 }
 

--- a/src/socket-io-adapter.ts
+++ b/src/socket-io-adapter.ts
@@ -1,6 +1,7 @@
 import { Server, Socket } from 'socket.io';
 import broadcasts, { Broadcast } from './broadcast.js';
 import { logger, uniqueName } from './util/index.js';
+import { spectatorJoins, spectatorLeaves, socketEmissions } from './metrics.js';
 import { EmitType } from '../shared/types.js';
 import type { BroadcastDelta } from '../shared/types.js';
 
@@ -21,6 +22,7 @@ io.on('connection', (socket: Socket) => {
     if (!broadcast) return;
 
     broadcast.browserCount++;
+    spectatorJoins.inc({ port: String(port), event: broadcast.game.site ?? 'unknown' });
 
     username = uniqueName(user, broadcast.spectators);
     if (username) broadcast.spectators.add(username);
@@ -53,6 +55,7 @@ io.on('connection', (socket: Socket) => {
     if (!broadcast) return;
 
     broadcast.browserCount--;
+    spectatorLeaves.inc({ port: String(broadcast.port), event: broadcast.game.site ?? 'unknown' });
 
     if (username) broadcast.spectators.delete(username);
 
@@ -61,10 +64,12 @@ io.on('connection', (socket: Socket) => {
 });
 
 export function emitUpdate(port: number, data: BroadcastDelta): void {
+  socketEmissions.inc({ port: String(port), event: broadcasts.get(port)?.game.site ?? 'unknown', type: 'update' });
   io.to(String(port)).emit(EmitType.UPDATE, data);
 }
 
 export function emitChat(port: number, messages: string[]): void {
+  socketEmissions.inc({ port: String(port), event: broadcasts.get(port)?.game.site ?? 'unknown', type: 'chat' });
   io.to(String(port)).emit(EmitType.CHAT, messages);
 }
 

--- a/src/transport/message-buffer.ts
+++ b/src/transport/message-buffer.ts
@@ -1,3 +1,4 @@
+import { messageBufferErrors } from '../metrics.js';
 import { logger } from '../util/index.js';
 
 const PROCESSING_INTERVAL = 100;
@@ -38,6 +39,7 @@ export class MessageBuffer {
       await this.consumer(messages);
     } catch (err) {
       logger.error(`Error processing messages - ${err}`, { port: this.port });
+      messageBufferErrors.inc({ port: String(this.port) });
     } finally {
       this.processing = false;
     }

--- a/src/transport/udp-transport.ts
+++ b/src/transport/udp-transport.ts
@@ -1,4 +1,6 @@
 import { RemoteInfo, Socket, createSocket } from 'dgram';
+import broadcasts from '../broadcast.js';
+import { udpMessagesReceived, udpMessagesOutOfOrder } from '../metrics.js';
 import { logger } from '../util/index.js';
 
 export type MessageCallback = (message: string) => void;
@@ -44,6 +46,9 @@ export class UdpTransport {
     logger.debug(`Message received from ${rInfo.address}:${rInfo.port}: ${msg}`, { port: this.port });
 
     const fullMessage = msg.toString().trim();
+    const event = broadcasts.get(this.port)?.game.site ?? 'unknown';
+    udpMessagesReceived.inc({ port: String(this.port), event });
+
     let messageText: string;
 
     if (fullMessage.startsWith('<')) {
@@ -58,6 +63,7 @@ export class UdpTransport {
           `Received an odd ordering of messages! Last: ${this.lastMessage}, Next: ${id}, SKIPPING PROCESSING!`,
           { port: this.port },
         );
+        udpMessagesOutOfOrder.inc({ port: String(this.port), event });
         return;
       }
 

--- a/src/transport/udp-transport.ts
+++ b/src/transport/udp-transport.ts
@@ -1,5 +1,4 @@
 import { RemoteInfo, Socket, createSocket } from 'dgram';
-import broadcasts from '../broadcast.js';
 import { udpMessagesReceived, udpMessagesOutOfOrder } from '../metrics.js';
 import { logger } from '../util/index.js';
 
@@ -46,8 +45,7 @@ export class UdpTransport {
     logger.debug(`Message received from ${rInfo.address}:${rInfo.port}: ${msg}`, { port: this.port });
 
     const fullMessage = msg.toString().trim();
-    const event = broadcasts.get(this.port)?.game.site ?? 'unknown';
-    udpMessagesReceived.inc({ port: String(this.port), event });
+    udpMessagesReceived.inc({ port: String(this.port) });
 
     let messageText: string;
 
@@ -63,7 +61,7 @@ export class UdpTransport {
           `Received an odd ordering of messages! Last: ${this.lastMessage}, Next: ${id}, SKIPPING PROCESSING!`,
           { port: this.port },
         );
-        udpMessagesOutOfOrder.inc({ port: String(this.port), event });
+        udpMessagesOutOfOrder.inc({ port: String(this.port) });
         return;
       }
 


### PR DESCRIPTION
## Summary

- Adds `GET /admin/metrics` endpoint for Prometheus pull-based scraping, behind existing basic auth
- Centralized `src/metrics.ts` module using `prom-client` with `ccrl_` prefix
- **Gauges** (collected at scrape time): active broadcasts, spectators, browser connections, move number, kibitzer status — labeled with `port` and `event`
- **Counters** (instrumented at call sites): UDP messages received/out-of-order, commands processed, chat messages, spectator joins/leaves, socket emissions, kibitzer assignments, message buffer errors — labeled with `port` only (no `event` to avoid unbounded cardinality)
- Default Node.js process metrics enabled (CPU, memory, event loop, GC)
- No PII collected — no usernames, IPs, or chat content in any metric or label

## Test plan

- [x] `npm run build` passes (TypeScript + webpack)
- [x] `npm run lint` clean
- [x] Manual verification: started dev server, curled `/admin/metrics`, confirmed all custom metrics and default process metrics appear with correct labels and values
- [x] Verified counter cardinality is bounded (event label only on gauges which reset each scrape)