### PR TITLE
feat: outbound webhook notifications (Discord)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,21 @@ The kibitzer runs chess engines (local or remote via SSH) that independently ana
 
 **Targeting**: `poll()` runs every 10s (and once immediately at startup), ranks broadcasts by viewer count, assigns the top N transports (where N = number of configured kibitzers). Highest-priority transport gets the most-viewed broadcast. Hysteresis threshold of 2 gives currently-analyzed broadcasts a ranking bonus. Broadcasts with zero viewers are excluded.
 
+### Webhook Subsystem
+
+Outbound webhooks POST a notification when a game **starts** or **finishes**. Configs are stored in `config.json` under the `webhooks` key and managed at runtime from the admin panel. The subsystem mirrors the kibitzer pattern (discriminated-union-by-`type`, config-backed, runtime-managed, admin-editable).
+
+**Files** (`src/webhooks/`):
+- `types.ts` - `WebhookConfig` discriminated union (`DiscordWebhookConfig` only for now), the normalized `WebhookEvent` payload (`GameStartedEvent | GameFinishedEvent`), and the `WebhookSender` interface
+- `discord-sender.ts` - `DiscordSender` formats events as Discord embeds and POSTs via Node's global `fetch`
+- `sender-factory.ts` - `createSender()` builds a sender from a config based on its `type`
+- `webhook-manager.ts` - `WebhookManager` owns the configs/senders; `dispatch()` applies port + event filters and fans out
+- `index.ts` - Barrel export
+
+**Data flow**: `GameService` calls `getWebhookManager()?.dispatch(event)` from `onPlayer()` (game-started) and `onResult()` (game-finished). `dispatch()` is **fire-and-forget** — it filters each webhook by `ports` (empty = all) and `events` (empty = both), then calls `sender.send()` without awaiting. Senders catch all errors internally and never throw, so a failed webhook never blocks game processing.
+
+**Game-started detection**: `onPlayer()` fires once per color. `GameService` uses a re-arm state machine (`gameStartArmed` + `startColorsSeen`) — armed at construction and re-armed after each `RESULT`, it fires exactly once per game when both colors have been announced. This avoids keying on the 100ms-debounced `currentGameNumber`.
+
 ### Frontend Architecture
 
 The frontend is TypeScript using jQuery and chessboardjs, bundled with Webpack.
@@ -156,6 +171,8 @@ The frontend is TypeScript using jQuery and chessboardjs, bundled with Webpack.
 - `/admin` - Admin panel (basic auth, username: admin)
 - `POST /admin/kibitzers` - Add a new kibitzer transport at runtime
 - `DELETE /admin/kibitzers/:id` - Remove a kibitzer transport at runtime
+- `POST /admin/webhooks` - Add a new webhook at runtime
+- `DELETE /admin/webhooks/:id` - Remove a webhook at runtime
 
 ### Client-Server Communication
 
@@ -188,11 +205,16 @@ Configuration is in `config/config.json`:
   "kibitzers": [
     { "id": "a1b2c3d4", "type": "local", "priority": 10, "enginePath": "/usr/bin/stockfish", "threads": 4, "hash": 512 },
     { "id": "e5f6g7h8", "type": "ssh", "priority": 5, "host": "example.com", "username": "user", "privateKeyPath": "/path/to/key", "enginePath": "/usr/bin/stockfish", "threads": 8, "hash": 2048 }
+  ],
+  "webhooks": [
+    { "id": "i9j0k1l2", "type": "discord", "name": "My channel", "url": "https://discord.com/api/webhooks/...", "ports": [16063], "events": ["game-finished"] }
   ]
 }
 ```
 
 The `kibitzers` array is optional. Each entry has an `id` (auto-assigned at startup if missing), a `type` (`"local"` or `"ssh"`), a `priority` (higher = assigned to more-viewed broadcasts), and type-specific fields. SSH entries also require `host`, `username`, `privateKeyPath`, and `enginePath`. Both types accept optional `port` (SSH only, default 22), `threads` (default 1), and `hash` (default 256).
+
+The `webhooks` array is also optional. Each entry has an `id` (auto-assigned if missing), a `type` (`"discord"` only for now), a `url`, an optional `name`, an optional `ports` array (empty/unset = all broadcasts), and an optional `events` array of `"game-started"` / `"game-finished"` (empty/unset = both).
 
 Environment variables:
 - `TLCV_PASSWORD` - Admin panel password (required)
@@ -216,6 +238,7 @@ Environment variables:
 - `src/broadcast-manager.ts` - Broadcast creation, reconnection, and lifecycle orchestration
 - `src/config/config-store.ts` - Config read/write abstraction for connections
 - `src/kibitzer/` - Analysis engine transports (local, SSH), manager, factory, UCI parser
+- `src/webhooks/` - Outbound webhook senders (Discord), manager, factory
 - `src/transport/` - UDP transport and message buffering
 - `src/services/` - External integrations (Lichess openings/tablebase, PGN saving, PGN cache, game metadata, result parsing)
 - `src/routes/` - Express route handlers (index, admin)
@@ -247,4 +270,7 @@ Environment variables:
 - **Kibitzer transport lifecycle**: Connection lifecycle (`create`/`teardown`) is separate from analysis lifecycle (`startAnalysis`/`stopAnalysis`). `create()` is called once at startup to establish the engine connection (SSH or local process) and UCI handshake. `teardown()` is only called during graceful shutdown. When moving between broadcasts, only `stopAnalysis()`/`startAnalysis()` are called — the underlying connection stays alive. No automatic restart if an engine crashes or SSH connection drops — `ready` becomes `false` and analysis silently stops.
 - **Kibitzer config IDs**: Each kibitzer config entry has a unique `id` field (8-char UUID prefix). Existing configs without IDs get them auto-assigned and saved on first startup. IDs are used for the admin DELETE route.
 - **Kibitzer runtime management**: `KibitzerManager` owns the full transport lifecycle from config. It accepts `KibitzerConfig[]` in the constructor and supports `addTransport(config)` / `removeTransport(id)` for runtime changes. The admin panel's "edit" is implemented as delete + re-add on the frontend.
+- **Webhook dispatch is fire-and-forget**: `WebhookManager.dispatch()` calls `sender.send()` without awaiting. `DiscordSender.send()` catches every error and always resolves, so a slow or failing webhook never blocks `onResult()` / the message batch. Do not `await` `dispatch()`.
+- **Webhook game-started dedup**: `GameService` fires one game-started event per game via a re-arm state machine (`gameStartArmed` / `startColorsSeen`). It is re-armed in `onResult()`. Connecting mid-game fires one game-started for the already-in-progress game — accepted.
+- **Webhook URL is a secret**: Discord webhook URLs embed a token. The admin table masks all but the last 8 chars, but the edit button still carries the full URL in a `data-url` attribute (admin page is basic-auth protected).
 - **No test infrastructure**: This project has no test runner or test files. Verification is done via `npm run build` (TypeScript + webpack) and manual testing.

--- a/public/css/_admin.scss
+++ b/public/css/_admin.scss
@@ -115,4 +115,27 @@
     display: none;
     margin-left: 0.5rem;
   }
+
+  #webhook-cancel {
+    display: none;
+    margin-left: 0.5rem;
+  }
+
+  .webhook-events {
+    display: flex;
+    gap: 16px;
+    margin-top: 4px;
+  }
+
+  .webhook-event-option {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 0;
+    font-weight: 400;
+
+    input {
+      width: auto;
+    }
+  }
 }

--- a/public/js/admin.ts
+++ b/public/js/admin.ts
@@ -103,6 +103,57 @@ function collectKibitzerFormData(): Record<string, string> {
   return data;
 }
 
+// --- Webhook handlers ---
+
+function removeWebhook(id: string) {
+  $.ajax({
+    type: 'DELETE',
+    url: `/admin/webhooks/${id}`,
+    complete() {
+      window.location.reload();
+    },
+  });
+}
+
+function addWebhook(data: Record<string, unknown>) {
+  $.ajax({
+    type: 'POST',
+    url: '/admin/webhooks',
+    data: JSON.stringify(data),
+    contentType: 'application/json',
+    complete() {
+      window.location.reload();
+    },
+  });
+}
+
+function resetWebhookForm() {
+  $('#webhook-editing-id').val('');
+  $('#webhook-type').val('discord');
+  $('#webhook-name').val('');
+  $('#webhook-url').val('');
+  $('#webhook-ports').val('');
+  $('#webhook-event-started').prop('checked', true);
+  $('#webhook-event-finished').prop('checked', true);
+  $('#webhook-form-legend').text('Add Webhook');
+  $('#webhook-submit').text('Add');
+  $('#webhook-cancel').hide();
+}
+
+function collectWebhookFormData(): Record<string, unknown> {
+  const events: string[] = [];
+  if ($('#webhook-event-started').prop('checked')) events.push('game-started');
+  if ($('#webhook-event-finished').prop('checked')) events.push('game-finished');
+
+  return {
+    type: $('#webhook-type').val() as string,
+    name: ($('#webhook-name').val() as string).trim(),
+    url: ($('#webhook-url').val() as string).trim(),
+    ports: ($('#webhook-ports').val() as string).trim(),
+    events,
+  };
+}
+
 $(document).ready(() => {
   initTheme();
 
@@ -173,6 +224,57 @@ $(document).ready(() => {
       });
     } else {
       addKibitzer(data);
+    }
+  });
+
+  // Webhook remove
+  $(document).on('click', '.webhook-remove', function handleWebhookRemove() {
+    const id = $(this).data('id');
+    removeWebhook(id);
+  });
+
+  // Webhook edit — populate form with row data
+  $(document).on('click', '.webhook-edit', function handleWebhookEdit() {
+    const $btn = $(this);
+    $('#webhook-editing-id').val($btn.data('id'));
+    $('#webhook-type').val($btn.data('type'));
+    $('#webhook-name').val(String($btn.data('name') ?? ''));
+    $('#webhook-url').val(String($btn.data('url') ?? ''));
+    $('#webhook-ports').val(String($btn.data('ports') ?? ''));
+    const events = String($btn.data('events') ?? '').split(',');
+    $('#webhook-event-started').prop('checked', events.includes('game-started'));
+    $('#webhook-event-finished').prop('checked', events.includes('game-finished'));
+    $('#webhook-form-legend').text('Edit Webhook');
+    $('#webhook-submit').text('Save');
+    $('#webhook-cancel').show();
+  });
+
+  // Webhook cancel edit
+  $('#webhook-cancel').on('click', (e) => {
+    e.preventDefault();
+    resetWebhookForm();
+  });
+
+  // Webhook form submit (add or edit)
+  $('#webhook-form').on('submit', (e) => {
+    e.preventDefault();
+    const editingId = ($('#webhook-editing-id').val() as string).trim();
+    const data = collectWebhookFormData();
+
+    if (editingId) {
+      // Edit = delete old, then add new
+      $.ajax({
+        type: 'DELETE',
+        url: `/admin/webhooks/${editingId}`,
+        success() {
+          addWebhook(data);
+        },
+        error() {
+          window.location.reload();
+        },
+      });
+    } else {
+      addWebhook(data);
     }
   });
 });

--- a/src/broadcast-manager.ts
+++ b/src/broadcast-manager.ts
@@ -2,6 +2,7 @@ import dns from 'dns';
 import broadcasts, { Broadcast } from './broadcast.js';
 import configStore from './config/config-store.js';
 import type { KibitzerManager } from './kibitzer/kibitzer-manager.js';
+import type { WebhookManager } from './webhooks/webhook-manager.js';
 
 const lookup = (hostname: string): Promise<string> =>
   new Promise((resolve, reject) => dns.lookup(hostname, (err, addr) => (err ? reject(err) : resolve(addr))));
@@ -14,6 +15,16 @@ export function setKibitzerManager(manager: KibitzerManager): void {
 
 export function getKibitzerManager(): KibitzerManager | null {
   return _kibitzerManager;
+}
+
+let _webhookManager: WebhookManager | null = null;
+
+export function setWebhookManager(manager: WebhookManager): void {
+  _webhookManager = manager;
+}
+
+export function getWebhookManager(): WebhookManager | null {
+  return _webhookManager;
 }
 
 export async function connect(): Promise<void> {

--- a/src/config/config-store.ts
+++ b/src/config/config-store.ts
@@ -1,10 +1,12 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { KibitzerConfig } from '../kibitzer/types.js';
+import type { WebhookConfig } from '../webhooks/types.js';
 
 export interface AppConfig {
   connections: string[];
   kibitzers?: KibitzerConfig[];
+  webhooks?: WebhookConfig[];
 }
 
 export class ConfigStore {
@@ -52,6 +54,20 @@ export class ConfigStore {
   async removeKibitzer(id: string): Promise<void> {
     const appConfig = await this.load();
     appConfig.kibitzers = (appConfig.kibitzers ?? []).filter((k) => k.id !== id);
+    await this.save(appConfig);
+  }
+
+  async addWebhook(config: WebhookConfig): Promise<void> {
+    const appConfig = await this.load();
+    const webhooks = appConfig.webhooks ?? [];
+    webhooks.push(config);
+    appConfig.webhooks = webhooks;
+    await this.save(appConfig);
+  }
+
+  async removeWebhook(id: string): Promise<void> {
+    const appConfig = await this.load();
+    appConfig.webhooks = (appConfig.webhooks ?? []).filter((w) => w.id !== id);
     await this.save(appConfig);
   }
 }

--- a/src/game-service.ts
+++ b/src/game-service.ts
@@ -2,6 +2,7 @@ import { Chess } from 'chess.js';
 import { ChessGame } from './chess-game.js';
 import { logger, siteSlug } from './util/index.js';
 import { Broadcast, username } from './broadcast.js';
+import { getWebhookManager } from './broadcast-manager.js';
 import { fetchOpening, fetchTablebase } from './services/lichess.js';
 import { savePgn } from './services/pgn.js';
 import { saveGameMeta, invalidate as invalidateMetaCache } from './services/game-meta.js';
@@ -55,6 +56,10 @@ class GameService {
   private gamesParseTimer: ReturnType<typeof setTimeout> | null = null;
   private dirty: DirtyFlags = freshFlags();
   private moveCountBefore = 0;
+  // "Game started" detection: armed for the first game, re-armed after each
+  // RESULT. Fires once both colors have been (re)announced for the new game.
+  private gameStartArmed = true;
+  private startColorsSeen = new Set<Color>();
 
   constructor(broadcast: Broadcast) {
     this.broadcast = broadcast;
@@ -140,6 +145,26 @@ class GameService {
 
     this.dirty.players = true;
     this.dirty.liveData = true;
+
+    // onPlayer fires once per color. Notify "game started" exactly once, when
+    // both colors have been announced for this game (independent of the
+    // 100ms-debounced currentGameNumber advance).
+    if (this.gameStartArmed) {
+      this.startColorsSeen.add(color);
+      if (this.startColorsSeen.size === 2) {
+        this.gameStartArmed = false;
+        this.startColorsSeen.clear();
+        getWebhookManager()?.dispatch({
+          kind: 'game-started',
+          port: this.broadcast.port,
+          gameNumber: this.broadcast.currentGameNumber,
+          white: this.game.white.name,
+          black: this.game.black.name,
+          site: this.game.site,
+        });
+      }
+    }
+
     return [EmitType.UPDATE, false];
   }
 
@@ -420,6 +445,21 @@ class GameService {
 
     await savePgn(this.game, this.broadcast.port, this.broadcast.currentGameNumber);
     await saveGameMeta(this.game, this.broadcast.port, this.broadcast.currentGameNumber, result);
+
+    getWebhookManager()?.dispatch({
+      kind: 'game-finished',
+      port: this.broadcast.port,
+      gameNumber: this.broadcast.currentGameNumber,
+      white: this.game.white.name,
+      black: this.game.black.name,
+      site: this.game.site,
+      result,
+      opening: this.game.opening,
+    });
+
+    // Re-arm "game started" detection for the next game.
+    this.gameStartArmed = true;
+    this.startColorsSeen.clear();
 
     this.broadcast.reloadResults();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,8 +5,9 @@ import http from 'http';
 import { app } from './app.js';
 import { io } from './socket-io-adapter.js';
 import { logger } from './util/index.js';
-import { connect, setKibitzerManager } from './broadcast-manager.js';
+import { connect, setKibitzerManager, setWebhookManager } from './broadcast-manager.js';
 import { KibitzerManager } from './kibitzer/index.js';
+import { WebhookManager } from './webhooks/index.js';
 import { loadAll as loadPgnCache } from './services/pgn-cache.js';
 import { loadAll as loadMetaCache } from './services/game-meta.js';
 import configStore from './config/config-store.js';
@@ -19,6 +20,7 @@ io.attach(server);
 
   const config = await configStore.load();
   const kibitzers = config.kibitzers ?? [];
+  const webhooks = config.webhooks ?? [];
 
   // Backfill IDs for configs created before runtime management was added
   let needsSave = false;
@@ -28,15 +30,24 @@ io.attach(server);
       needsSave = true;
     }
   }
+  for (const w of webhooks) {
+    if (!w.id) {
+      w.id = crypto.randomUUID().slice(0, 8);
+      needsSave = true;
+    }
+  }
   if (needsSave) {
     config.kibitzers = kibitzers;
+    config.webhooks = webhooks;
     await configStore.save(config);
-    logger.info('Assigned IDs to kibitzer configs missing them');
+    logger.info('Assigned IDs to configs missing them');
   }
 
   const kibitzerManager = new KibitzerManager(kibitzers);
+  const webhookManager = new WebhookManager(webhooks);
 
   setKibitzerManager(kibitzerManager);
+  setWebhookManager(webhookManager);
   await connect();
 
   kibitzerManager.start();

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -3,9 +3,10 @@ import { Router, Request, Response } from 'express';
 import basic from 'express-basic-auth';
 import broadcasts from '../broadcast.js';
 import { logger } from '../util/index.js';
-import { closeConnection, getKibitzerManager, newConnection } from '../broadcast-manager.js';
+import { closeConnection, getKibitzerManager, getWebhookManager, newConnection } from '../broadcast-manager.js';
 import configStore from '../config/config-store.js';
 import type { KibitzerConfig } from '../kibitzer/types.js';
+import type { WebhookConfig, WebhookEventKind } from '../webhooks/types.js';
 import { register } from '../metrics.js';
 
 const router = Router();
@@ -22,6 +23,7 @@ router.get('/', (_: Request, res: Response) => {
   res.render('pages/admin', {
     broadcasts: broadcasts.values(),
     kibitzers: kibitzerManager?.getStatus() ?? [],
+    webhooks: getWebhookManager()?.getStatus() ?? [],
   });
 });
 
@@ -111,6 +113,62 @@ router.delete('/kibitzers/:id', async (req: Request, res: Response) => {
     res.sendStatus(200);
   } catch (error) {
     logger.warn(`Unable to remove kibitzer ${id}`);
+    logger.error(error);
+    res.sendStatus(400);
+  }
+});
+
+router.post('/webhooks', async (req: Request, res: Response) => {
+  const body = req.body;
+
+  try {
+    if (!body.url || body.type !== 'discord') {
+      res.sendStatus(400);
+      return;
+    }
+
+    const id = crypto.randomUUID().slice(0, 8);
+
+    const ports = String(body.ports ?? '')
+      .split(',')
+      .map((s) => parseInt(s.trim(), 10))
+      .filter((n) => !Number.isNaN(n));
+
+    const rawEvents: string[] = Array.isArray(body.events) ? body.events : body.events ? [body.events] : [];
+    const events = rawEvents.filter((e): e is WebhookEventKind => e === 'game-started' || e === 'game-finished');
+
+    const config: WebhookConfig = {
+      id,
+      type: 'discord',
+      name: body.name || undefined,
+      url: body.url,
+      ports: ports.length ? ports : undefined,
+      events: events.length ? events : undefined,
+    };
+
+    await configStore.addWebhook(config);
+    getWebhookManager()?.addWebhook(config);
+
+    logger.info(`Added webhook ${id}`);
+    res.sendStatus(200);
+  } catch (error) {
+    logger.warn('Unable to add webhook');
+    logger.error(error);
+    res.sendStatus(400);
+  }
+});
+
+router.delete('/webhooks/:id', async (req: Request, res: Response) => {
+  const { id } = req.params;
+
+  try {
+    getWebhookManager()?.removeWebhook(id);
+    await configStore.removeWebhook(id);
+
+    logger.info(`Removed webhook ${id}`);
+    res.sendStatus(200);
+  } catch (error) {
+    logger.warn(`Unable to remove webhook ${id}`);
     logger.error(error);
     res.sendStatus(400);
   }

--- a/src/webhooks/discord-sender.ts
+++ b/src/webhooks/discord-sender.ts
@@ -1,0 +1,79 @@
+import { logger } from '../util/index.js';
+import type { WebhookEvent, WebhookSender } from './types.js';
+
+const PUBLIC_BASE = 'https://ccrl.live';
+
+const COLOR_STARTED = 0x4caf50; // green
+const COLOR_FINISHED = 0x2196f3; // blue
+
+type DiscordEmbed = {
+  title: string;
+  url: string;
+  description: string;
+  color: number;
+  fields: Array<{ name: string; value: string; inline?: boolean }>;
+  timestamp: string;
+};
+
+/**
+ * Formats webhook events as Discord embeds and POSTs them to a Discord
+ * incoming-webhook URL. The full PGN is intentionally omitted — it can blow
+ * past Discord's 1024-char field / 6000-char embed limits — so the embed
+ * links to the live broadcast instead.
+ */
+export class DiscordSender implements WebhookSender {
+  type(): string {
+    return 'discord';
+  }
+
+  async send(event: WebhookEvent, url: string): Promise<void> {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ embeds: [this.buildEmbed(event)] }),
+      });
+      if (!res.ok) {
+        logger.warn(
+          `Webhook(discord): POST failed ${res.status} ${res.statusText} for game ${event.gameNumber} on port ${event.port}`,
+        );
+      }
+    } catch (err) {
+      logger.error(`Webhook(discord): network error for port ${event.port}: ${err}`);
+    }
+  }
+
+  private buildEmbed(event: WebhookEvent): DiscordEmbed {
+    const broadcastUrl = `${PUBLIC_BASE}/${event.port}`;
+    const matchup = `${event.white} vs ${event.black}`;
+    const link = `[ccrl.live/${event.port}](${broadcastUrl})`;
+
+    if (event.kind === 'game-started') {
+      return {
+        title: `♟ Game ${event.gameNumber} started`,
+        url: broadcastUrl,
+        description: `**${matchup}**`,
+        color: COLOR_STARTED,
+        fields: [
+          { name: 'Event', value: event.site || 'Unknown', inline: true },
+          { name: 'Watch live', value: link, inline: true },
+        ],
+        timestamp: new Date().toISOString(),
+      };
+    }
+
+    return {
+      title: `♟ Game ${event.gameNumber} finished — ${event.result}`,
+      url: broadcastUrl,
+      description: `**${matchup}**`,
+      color: COLOR_FINISHED,
+      fields: [
+        { name: 'Result', value: event.result || '*', inline: true },
+        { name: 'Event', value: event.site || 'Unknown', inline: true },
+        { name: 'Opening', value: event.opening || 'Unknown', inline: false },
+        { name: 'Watch / replay', value: link, inline: false },
+      ],
+      timestamp: new Date().toISOString(),
+    };
+  }
+}

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -1,0 +1,4 @@
+export { WebhookManager } from './webhook-manager.js';
+export type { WebhookStatus } from './webhook-manager.js';
+export { createSender } from './sender-factory.js';
+export type { WebhookConfig, WebhookEvent, WebhookEventKind, WebhookSender } from './types.js';

--- a/src/webhooks/sender-factory.ts
+++ b/src/webhooks/sender-factory.ts
@@ -1,0 +1,13 @@
+import { logger } from '../util/index.js';
+import { DiscordSender } from './discord-sender.js';
+import type { WebhookConfig, WebhookSender } from './types.js';
+
+export function createSender(config: WebhookConfig): WebhookSender {
+  switch (config.type) {
+    case 'discord':
+      logger.info(`Webhook: creating DiscordSender (${config.id})`);
+      return new DiscordSender();
+    default:
+      throw new Error(`Webhook: unknown sender type "${(config as WebhookConfig).type}"`);
+  }
+}

--- a/src/webhooks/types.ts
+++ b/src/webhooks/types.ts
@@ -1,0 +1,43 @@
+export type WebhookEventKind = 'game-started' | 'game-finished';
+
+export type DiscordWebhookConfig = {
+  id: string; // 8-char uuid prefix, auto-assigned
+  type: 'discord';
+  name?: string; // human label for the admin table
+  url: string; // Discord webhook URL (secret)
+  ports?: number[]; // empty/unset => all broadcasts
+  events?: WebhookEventKind[]; // empty/unset => both events
+};
+
+// Discriminated union by `type` — only Discord today, ready to grow.
+export type WebhookConfig = DiscordWebhookConfig;
+
+// Normalized payload passed to senders — senders never touch ChessGame.
+export type GameStartedEvent = {
+  kind: 'game-started';
+  port: number;
+  gameNumber: number;
+  white: string;
+  black: string;
+  site: string;
+};
+
+export type GameFinishedEvent = {
+  kind: 'game-finished';
+  port: number;
+  gameNumber: number;
+  white: string;
+  black: string;
+  site: string;
+  result: string;
+  opening: string;
+};
+
+export type WebhookEvent = GameStartedEvent | GameFinishedEvent;
+
+export interface WebhookSender {
+  // Fire-and-forget; implementations must never throw and always resolve,
+  // even on HTTP/network failure (logged internally).
+  send(event: WebhookEvent, url: string): Promise<void>;
+  type(): string;
+}

--- a/src/webhooks/webhook-manager.ts
+++ b/src/webhooks/webhook-manager.ts
@@ -1,0 +1,74 @@
+import { logger } from '../util/index.js';
+import { createSender } from './sender-factory.js';
+import type { WebhookConfig, WebhookEvent, WebhookEventKind, WebhookSender } from './types.js';
+
+interface WebhookEntry {
+  id: string;
+  config: WebhookConfig;
+  sender: WebhookSender;
+}
+
+export interface WebhookStatus {
+  id: string;
+  type: string;
+  name: string;
+  url: string;
+  ports: number[];
+  events: WebhookEventKind[];
+}
+
+/**
+ * Owns the configured outbound webhooks. Unlike KibitzerManager there are no
+ * timers or polling — webhooks are purely event-driven, so construction alone
+ * makes the manager ready. `dispatch()` is fire-and-forget and never throws.
+ */
+export class WebhookManager {
+  private entries: WebhookEntry[] = [];
+
+  constructor(configs: WebhookConfig[]) {
+    for (const config of configs) {
+      try {
+        this.entries.push({ id: config.id, config, sender: createSender(config) });
+      } catch (e) {
+        logger.warn(`WebhookManager: failed to create sender ${config.id}: ${e}`);
+      }
+    }
+  }
+
+  addWebhook(config: WebhookConfig): void {
+    this.entries.push({ id: config.id, config, sender: createSender(config) });
+    logger.info(`WebhookManager: added webhook ${config.id} (${config.type})`);
+  }
+
+  removeWebhook(id: string): void {
+    const idx = this.entries.findIndex((e) => e.id === id);
+    if (idx === -1) return;
+
+    this.entries.splice(idx, 1);
+    logger.info(`WebhookManager: removed webhook ${id}`);
+  }
+
+  getStatus(): WebhookStatus[] {
+    return this.entries.map((e) => ({
+      id: e.id,
+      type: e.config.type,
+      name: e.config.name ?? '',
+      url: e.config.url,
+      ports: e.config.ports ?? [],
+      events: e.config.events ?? ['game-started', 'game-finished'],
+    }));
+  }
+
+  // Fire-and-forget. Never throws, never meant to be awaited by the caller.
+  dispatch(event: WebhookEvent): void {
+    for (const { config, sender } of this.entries) {
+      // Port filter: empty/unset => all ports.
+      if (config.ports && config.ports.length > 0 && !config.ports.includes(event.port)) continue;
+      // Event filter: empty/unset => both events.
+      if (config.events && config.events.length > 0 && !config.events.includes(event.kind)) continue;
+
+      // Intentionally not awaited — the sender swallows its own errors.
+      sender.send(event, config.url);
+    }
+  }
+}

--- a/views/pages/admin.ejs
+++ b/views/pages/admin.ejs
@@ -140,6 +140,84 @@
           </fieldset>
         </form>
       </div>
+
+      <hr class="admin-divider" />
+
+      <div class="admin-section">
+        <h2>Webhooks</h2>
+        <% if (webhooks.length > 0) { %>
+        <table class="admin-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Type</th>
+              <th>URL</th>
+              <th>Ports</th>
+              <th>Events</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% for (const w of webhooks) { %>
+            <tr>
+              <td data-label="Name"><%= w.name || '—' %></td>
+              <td data-label="Type"><%= w.type %></td>
+              <td data-label="URL"><%= '••••' + w.url.slice(-8) %></td>
+              <td data-label="Ports"><%= w.ports.length ? w.ports.join(', ') : 'all' %></td>
+              <td data-label="Events"><%= w.events.join(', ') %></td>
+              <td data-label="Actions">
+                <button class="secondary webhook-edit"
+                  data-id="<%= w.id %>"
+                  data-type="<%= w.type %>"
+                  data-name="<%= w.name %>"
+                  data-url="<%= w.url %>"
+                  data-ports="<%= w.ports.join(',') %>"
+                  data-events="<%= w.events.join(',') %>"
+                >Edit</button>
+                <button class="secondary webhook-remove" data-id="<%= w.id %>">Remove</button>
+              </td>
+            </tr>
+            <% } %>
+          </tbody>
+        </table>
+        <% } else { %>
+        <p>No webhooks configured.</p>
+        <% } %>
+
+        <form id="webhook-form" class="admin-form">
+          <input type="hidden" id="webhook-editing-id" value="" />
+          <fieldset>
+            <legend id="webhook-form-legend">Add Webhook</legend>
+
+            <label for="webhook-type">Type</label>
+            <select id="webhook-type" name="type">
+              <option value="discord">Discord</option>
+            </select>
+
+            <label for="webhook-name">Name</label>
+            <input id="webhook-name" name="name" placeholder="My Discord channel" />
+
+            <label for="webhook-url">URL</label>
+            <input id="webhook-url" name="url" required placeholder="https://discord.com/api/webhooks/..." />
+
+            <label for="webhook-ports">Ports</label>
+            <input id="webhook-ports" name="ports" placeholder="blank = all, or e.g. 16063, 16064" />
+
+            <label>Events</label>
+            <div class="webhook-events">
+              <label class="webhook-event-option">
+                <input type="checkbox" id="webhook-event-started" value="game-started" checked /> Game started
+              </label>
+              <label class="webhook-event-option">
+                <input type="checkbox" id="webhook-event-finished" value="game-finished" checked /> Game finished
+              </label>
+            </div>
+
+            <button type="submit" id="webhook-submit" class="primary">Add</button>
+            <a href="#" id="webhook-cancel">Cancel</a>
+          </fieldset>
+        </form>
+      </div>
     </div>
     <%- include('../partials/footer') %>
   </body>


### PR DESCRIPTION
Resolves #56.

## What

Adds a configurable **outbound webhook** layer that POSTs a notification when a game **starts** or **finishes**. Each webhook has a `type` that selects the payload format — **Discord** is the only type for now, sending a rich embed that links to the live broadcast.

Webhooks are stored in `config.json` under a `webhooks` key, managed at runtime from the **admin panel**, and can be scoped to specific broadcast `ports` (blank = all) and `events` (blank = both).

## How

New `src/webhooks/` module, deliberately mirroring the kibitzer subsystem (discriminated-union-by-`type`, config-backed, runtime-managed, admin-editable):

| File | Role |
|------|------|
| `types.ts` | `WebhookConfig` union + normalized `WebhookEvent` payloads + `WebhookSender` interface |
| `discord-sender.ts` | Formats events as Discord embeds, POSTs via Node's global `fetch` |
| `sender-factory.ts` | `createSender()` dispatch by `type` |
| `webhook-manager.ts` | Owns configs/senders; `dispatch()` applies port + event filters |

- `GameService` dispatches `game-finished` from `onResult()` and `game-started` from `onPlayer()`.
- **Fire-and-forget:** `dispatch()` never awaits; senders catch all errors and never throw, so a slow or failing webhook cannot block game processing.
- **Game-started** uses a re-arm state machine so it fires exactly once per game even though `onPlayer()` runs once per color.
- Admin panel gains a Webhooks section (add / edit / remove) backed by `POST` / `DELETE /admin/webhooks`.

## Secrets

Issue #56 notes webhook URLs should be kept out of GitHub. Webhook URLs embed a token, so:
- This PR does **not** commit any `config.json` webhook entries — they are managed locally / via the admin panel.
- The admin table masks all but the last 8 characters of each URL.

`config/config.json` remains a tracked file; consider whether to `.gitignore` local config in a follow-up.

## Verification

- `npm run build` (webpack + `tsc`) and `npm run lint` pass clean.
- Manual: add a webhook at `/admin` pointing at a `webhook.site` capture URL (or a real Discord webhook), then confirm a game start/finish delivers the embed with the `ccrl.live/<port>` link. Port- and event-scoping and runtime add/remove all verified against a live broadcast.

---
Implemented by Claude Agent on Jay's behalf.