### PR TITLE
fix: clean up admin page styling and dark-mode regressions

### DIFF
--- a/public/css/_admin.scss
+++ b/public/css/_admin.scss
@@ -1,5 +1,9 @@
+@use 'mixins' as *;
+
+$admin-max-width: 900px;
+
 .admin-section {
-  max-width: 900px;
+  max-width: $admin-max-width;
   margin: 0 auto;
   padding: 0 16px 24px;
 
@@ -11,42 +15,38 @@
 }
 
 .admin-divider {
-  max-width: 900px;
+  max-width: $admin-max-width;
   margin: 8px auto 24px;
   border: none;
   border-top: 1px solid var(--surfaceColorHover);
 }
 
+.admin-empty {
+  @include table-status-message;
+  margin-bottom: 16px;
+}
+
 .admin-table {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
+  @include mini-table-reset;
   background: var(--surfaceColor);
   border: 1px solid var(--surfaceColorHover);
   border-radius: 8px;
   overflow: hidden;
   margin-bottom: 16px;
 
-  thead {
-    background: var(--surfaceColorHover);
+  thead th {
+    @include sticky-th-header;
   }
 
-  th {
-    font-weight: 600;
-    font-size: 0.85em;
-    text-align: left;
-    padding: 10px 12px;
-    color: var(--textColor);
-  }
-
-  td {
-    padding: 10px 12px;
+  tbody td {
+    padding: 6px 8px;
     font-size: 0.9em;
     color: var(--textColor);
+    vertical-align: middle;
     border-top: 1px solid var(--surfaceColorHover);
   }
 
-  tr:hover td {
+  tbody tr:hover td {
     background: var(--surfaceColorHover);
   }
 
@@ -60,14 +60,19 @@
 }
 
 .admin-form {
-  max-width: 500px;
+  // Neutralize mini.css's default <form> "card" chrome so the <fieldset> is
+  // the only card (avoids the card-in-card look).
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  box-shadow: none;
 
   label {
     display: block;
     font-size: 0.85em;
     font-weight: 600;
-    margin-bottom: 4px;
-    margin-top: 12px;
+    margin: 0 0 4px;
     color: var(--textColor);
   }
 
@@ -90,9 +95,11 @@
   }
 
   fieldset {
+    display: block;
     border: 1px solid var(--surfaceColorHover);
     border-radius: 8px;
     padding: 16px;
+    margin: 0;
     background: var(--surfaceColor);
   }
 
@@ -100,25 +107,38 @@
     font-weight: 600;
     font-size: 1rem;
     color: var(--textColor);
-    padding: 0 8px;
+    padding: 0;
+    margin-bottom: 12px;
   }
 
-  button[type='submit'] {
+  // Two-column field grid; full-width fields opt in via .field--full.
+  .admin-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px 16px;
+  }
+
+  .field--full {
+    grid-column: 1 / -1;
+  }
+
+  // SSH-only block is shown/hidden by admin.ts; it spans the row and lays its
+  // own fields out in the same two-column grid.
+  #ssh-fields {
+    display: none;
+    margin-top: 12px;
+  }
+
+  .admin-form-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
     margin-top: 16px;
   }
 
-  #ssh-fields {
-    display: none;
-  }
-
-  #kibitzer-cancel {
-    display: none;
-    margin-left: 0.5rem;
-  }
-
+  #kibitzer-cancel,
   #webhook-cancel {
     display: none;
-    margin-left: 0.5rem;
   }
 
   .webhook-events {
@@ -131,11 +151,24 @@
     display: flex;
     align-items: center;
     gap: 6px;
-    margin-top: 0;
+    margin: 0;
     font-weight: 400;
 
     input {
       width: auto;
     }
+  }
+}
+
+// Connection form: a single inline row rather than a card.
+.admin-form--inline {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  margin-bottom: 8px;
+
+  .field {
+    flex: 1;
+    max-width: 400px;
   }
 }

--- a/public/css/_responsive.scss
+++ b/public/css/_responsive.scss
@@ -76,4 +76,52 @@
     width: 80px;
     height: 80px;
   }
+
+  // Admin: forms collapse to one column.
+  .admin-form .admin-grid {
+    grid-template-columns: 1fr;
+  }
+
+  // Admin: tables become stacked cards using each cell's data-label.
+  .admin-table {
+    display: block;
+
+    thead {
+      display: none;
+    }
+
+    tbody,
+    tbody tr,
+    tbody td {
+      display: block;
+    }
+
+    tbody tr {
+      border-top: 1px solid var(--surfaceColorHover);
+
+      &:first-child {
+        border-top: 0;
+      }
+    }
+
+    tbody td {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      border: 0;
+      padding: 6px 10px;
+      text-align: right;
+
+      &::before {
+        content: attr(data-label);
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        text-align: left;
+        opacity: 0.7;
+      }
+    }
+  }
 }

--- a/views/pages/admin.ejs
+++ b/views/pages/admin.ejs
@@ -28,7 +28,7 @@
           <tbody>
             <% for (const broadcast of broadcasts) {%>
             <tr>
-              <td data-label="Site"><%= broadcast.game.site %></td>
+              <td data-label="Site"><%= broadcast.game.site || '—' %></td>
               <td data-label="Host"><%= broadcast.host %></td>
               <td data-label="Port"><%= broadcast.port %></td>
               <td data-label="Close">
@@ -38,9 +38,11 @@
             <% } %>
           </tbody>
         </table>
-        <form id="add-new" class="admin-form">
-          <label for="connection">Connection</label>
-          <input id="connection" name="connection" required placeholder="GrahamCCRL.dyndns.org:16000" />
+        <form id="add-new" class="admin-form admin-form--inline">
+          <div class="field">
+            <label for="connection">Connection</label>
+            <input id="connection" name="connection" required placeholder="GrahamCCRL.dyndns.org:16000" />
+          </div>
           <button type="submit" class="primary">Add new</button>
         </form>
       </div>
@@ -95,7 +97,7 @@
           </tbody>
         </table>
         <% } else { %>
-        <p>No kibitzers configured.</p>
+        <p class="admin-empty">No kibitzers configured.</p>
         <% } %>
 
         <form id="kibitzer-form" class="admin-form">
@@ -103,40 +105,64 @@
           <fieldset>
             <legend id="kibitzer-form-legend">Add Kibitzer</legend>
 
-            <label for="kibitzer-type">Type</label>
-            <select id="kibitzer-type" name="type">
-              <option value="local">Local</option>
-              <option value="ssh">SSH</option>
-            </select>
+            <div class="admin-grid">
+              <div class="field">
+                <label for="kibitzer-type">Type</label>
+                <select id="kibitzer-type" name="type">
+                  <option value="local">Local</option>
+                  <option value="ssh">SSH</option>
+                </select>
+              </div>
 
-            <label for="kibitzer-priority">Priority</label>
-            <input id="kibitzer-priority" name="priority" type="number" value="1" min="1" required />
+              <div class="field">
+                <label for="kibitzer-priority">Priority</label>
+                <input id="kibitzer-priority" name="priority" type="number" value="1" min="1" required />
+              </div>
 
-            <label for="kibitzer-engine-path">Engine Path</label>
-            <input id="kibitzer-engine-path" name="enginePath" placeholder="stockfish" />
+              <div class="field field--full">
+                <label for="kibitzer-engine-path">Engine Path</label>
+                <input id="kibitzer-engine-path" name="enginePath" placeholder="stockfish" />
+              </div>
 
-            <label for="kibitzer-threads">Threads</label>
-            <input id="kibitzer-threads" name="threads" type="number" value="1" min="1" />
+              <div class="field">
+                <label for="kibitzer-threads">Threads</label>
+                <input id="kibitzer-threads" name="threads" type="number" value="1" min="1" />
+              </div>
 
-            <label for="kibitzer-hash">Hash (MB)</label>
-            <input id="kibitzer-hash" name="hash" type="number" value="256" min="1" />
-
-            <div id="ssh-fields">
-              <label for="kibitzer-host">Host</label>
-              <input id="kibitzer-host" name="host" placeholder="example.com" />
-
-              <label for="kibitzer-port">Port</label>
-              <input id="kibitzer-port" name="port" type="number" value="22" />
-
-              <label for="kibitzer-username">Username</label>
-              <input id="kibitzer-username" name="username" />
-
-              <label for="kibitzer-private-key-path">Private Key Path</label>
-              <input id="kibitzer-private-key-path" name="privateKeyPath" placeholder="/home/user/.ssh/id_rsa" />
+              <div class="field">
+                <label for="kibitzer-hash">Hash (MB)</label>
+                <input id="kibitzer-hash" name="hash" type="number" value="256" min="1" />
+              </div>
             </div>
 
-            <button type="submit" id="kibitzer-submit" class="primary">Add</button>
-            <a href="#" id="kibitzer-cancel">Cancel</a>
+            <div id="ssh-fields">
+              <div class="admin-grid">
+                <div class="field">
+                  <label for="kibitzer-host">Host</label>
+                  <input id="kibitzer-host" name="host" placeholder="example.com" />
+                </div>
+
+                <div class="field">
+                  <label for="kibitzer-port">Port</label>
+                  <input id="kibitzer-port" name="port" type="number" value="22" />
+                </div>
+
+                <div class="field">
+                  <label for="kibitzer-username">Username</label>
+                  <input id="kibitzer-username" name="username" />
+                </div>
+
+                <div class="field field--full">
+                  <label for="kibitzer-private-key-path">Private Key Path</label>
+                  <input id="kibitzer-private-key-path" name="privateKeyPath" placeholder="/home/user/.ssh/id_rsa" />
+                </div>
+              </div>
+            </div>
+
+            <div class="admin-form-actions">
+              <button type="submit" id="kibitzer-submit" class="primary">Add</button>
+              <a href="#" id="kibitzer-cancel">Cancel</a>
+            </div>
           </fieldset>
         </form>
       </div>
@@ -181,7 +207,7 @@
           </tbody>
         </table>
         <% } else { %>
-        <p>No webhooks configured.</p>
+        <p class="admin-empty">No webhooks configured.</p>
         <% } %>
 
         <form id="webhook-form" class="admin-form">
@@ -189,32 +215,46 @@
           <fieldset>
             <legend id="webhook-form-legend">Add Webhook</legend>
 
-            <label for="webhook-type">Type</label>
-            <select id="webhook-type" name="type">
-              <option value="discord">Discord</option>
-            </select>
+            <div class="admin-grid">
+              <div class="field">
+                <label for="webhook-type">Type</label>
+                <select id="webhook-type" name="type">
+                  <option value="discord">Discord</option>
+                </select>
+              </div>
 
-            <label for="webhook-name">Name</label>
-            <input id="webhook-name" name="name" placeholder="My Discord channel" />
+              <div class="field">
+                <label for="webhook-name">Name</label>
+                <input id="webhook-name" name="name" placeholder="My Discord channel" />
+              </div>
 
-            <label for="webhook-url">URL</label>
-            <input id="webhook-url" name="url" required placeholder="https://discord.com/api/webhooks/..." />
+              <div class="field field--full">
+                <label for="webhook-url">URL</label>
+                <input id="webhook-url" name="url" required placeholder="https://discord.com/api/webhooks/..." />
+              </div>
 
-            <label for="webhook-ports">Ports</label>
-            <input id="webhook-ports" name="ports" placeholder="blank = all, or e.g. 16063, 16064" />
+              <div class="field field--full">
+                <label for="webhook-ports">Ports</label>
+                <input id="webhook-ports" name="ports" placeholder="blank = all, or e.g. 16063, 16064" />
+              </div>
 
-            <label>Events</label>
-            <div class="webhook-events">
-              <label class="webhook-event-option">
-                <input type="checkbox" id="webhook-event-started" value="game-started" checked /> Game started
-              </label>
-              <label class="webhook-event-option">
-                <input type="checkbox" id="webhook-event-finished" value="game-finished" checked /> Game finished
-              </label>
+              <div class="field field--full">
+                <label>Events</label>
+                <div class="webhook-events">
+                  <label class="webhook-event-option">
+                    <input type="checkbox" id="webhook-event-started" value="game-started" checked /> Game started
+                  </label>
+                  <label class="webhook-event-option">
+                    <input type="checkbox" id="webhook-event-finished" value="game-finished" checked /> Game finished
+                  </label>
+                </div>
+              </div>
             </div>
 
-            <button type="submit" id="webhook-submit" class="primary">Add</button>
-            <a href="#" id="webhook-cancel">Cancel</a>
+            <div class="admin-form-actions">
+              <button type="submit" id="webhook-submit" class="primary">Add</button>
+              <a href="#" id="webhook-cancel">Cancel</a>
+            </div>
           </fieldset>
         </form>
       </div>


### PR DESCRIPTION
## Summary

Reworks the `/admin` page to reuse the project's existing table/mixin patterns so it themes correctly and reads cleanly. The headline fix is **dark mode**, which was visibly broken on this page. The change also removes a card-in-a-card, unifies form/table widths, adds a 2-column form grid, styles the empty states, and wires up mobile — with **no behavior changes**.

## Screenshots

### Dark mode

| Before | After |
|---|---|
| ![admin dark before](https://raw.githubusercontent.com/jhonnold/node-tlcv/c5d886cac462cbd048cfbf29da9ab4a80aa60998/shot-before-dark.png) | ![admin dark after](https://raw.githubusercontent.com/jhonnold/node-tlcv/c5d886cac462cbd048cfbf29da9ab4a80aa60998/shot-after-dark.png) |

Before: table rows and form cards render white (mini.css defaults ignore the theme tokens) and the legend is barely legible. After: fully themed.

### Light mode

| Before | After |
|---|---|
| ![admin light before](https://raw.githubusercontent.com/jhonnold/node-tlcv/c5d886cac462cbd048cfbf29da9ab4a80aa60998/shot-before-light.png) | ![admin light after](https://raw.githubusercontent.com/jhonnold/node-tlcv/c5d886cac462cbd048cfbf29da9ab4a80aa60998/shot-after-light.png) |

Before: the add-forms sit in a card-in-a-card and stop at ~half width, leaving a dead gutter. After: one clean card per section, a 2-column field grid, and unified widths.

### Mobile (after)

<img src="https://raw.githubusercontent.com/jhonnold/node-tlcv/c5d886cac462cbd048cfbf29da9ab4a80aa60998/shot-after-mobile.png" width="380" alt="admin mobile after" />

Tables collapse into labeled stacked cards (via the already-present `data-label` attributes); forms go single-column.

## Root cause

The admin tables and forms never reset mini.css, so their cell/form backgrounds used mini.css's hardcoded light colors that ignore the theme's CSS custom properties. Switching to the existing `mini-table-reset` mixin + token-only colors (the same pattern the `results`/`games` tables already use) fixes dark mode with **zero** `dark-theme.scss` changes.

## What changed

- **`public/css/_admin.scss`** — rewritten with `mini-table-reset` + `sticky-th-header` on tables (token-only colors), mini.css form chrome neutralized so the `<fieldset>` is the single card, a 2-column `.admin-grid` (`.field` / `.field--full`), and an `.admin-empty` empty-state.
- **`views/pages/admin.ejs`** — fields wrapped in `.field` divs for the grid, `.admin-empty` on the empty-state text, and a `—` fallback for an empty Site cell. All element IDs, classes, and `data-*` preserved.
- **`public/css/_responsive.scss`** — forms collapse to one column on mobile; tables render as `data-label` stacked cards.
- **`public/css/dark-theme.scss`** — unchanged (intentionally; the token-only rewrite means the existing `:root` overrides cover the admin page automatically).

## Verification

- `npm run build` passes (tsc + webpack — the project's only build check).
- Verified in-browser across light, dark, and mobile.
- Added → edited → removed a webhook to confirm table rendering and that the edit-populate flow (driven by element IDs and `data-*`) still works after the markup restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
