### PR TITLE
fix: stop retrying Lichess opening lookups once they fail per game

### DIFF
--- a/src/chess-game.ts
+++ b/src/chess-game.ts
@@ -101,6 +101,7 @@ export class ChessGame {
   site: string;
   fen: string;
   opening: string;
+  openingLookupDisabled: boolean;
   tablebase: string;
   moveNumber: number;
   fmr: number;
@@ -122,6 +123,7 @@ export class ChessGame {
 
     this.fen = this.instance.fen();
     this.opening = 'Unknown';
+    this.openingLookupDisabled = false;
     this.tablebase = '';
     this.moveNumber = 1;
     this.fmr = 0;
@@ -144,6 +146,7 @@ export class ChessGame {
 
     this.fen = this.instance.fen();
     this.opening = 'Unknown';
+    this.openingLookupDisabled = false;
     this.tablebase = '';
     this.moveNumber = this.instance.moveNumber();
     this.fmr = 0;

--- a/src/game-service.ts
+++ b/src/game-service.ts
@@ -4,6 +4,7 @@ import { logger, siteSlug } from './util/index.js';
 import { Broadcast, username } from './broadcast.js';
 import { getWebhookManager } from './broadcast-manager.js';
 import { fetchOpening, fetchTablebase } from './services/lichess.js';
+import type { OpeningResult } from './services/lichess.js';
 import { savePgn } from './services/pgn.js';
 import { saveGameMeta, invalidate as invalidateMetaCache } from './services/game-meta.js';
 import { invalidate as invalidatePgnCache } from './services/pgn-cache.js';
@@ -322,12 +323,20 @@ class GameService {
 
     this.broadcast.kibitzerManager?.onPositionChange(this.broadcast.port, this.game.instance.fen());
 
-    const [opening, tablebase] = await Promise.all([
-      fetchOpening(this.game.name, this.game.instance),
+    const skipOpening = this.game.openingLookupDisabled || this.game.startFen !== null;
+
+    const [openingResult, tablebase] = await Promise.all([
+      skipOpening
+        ? Promise.resolve<OpeningResult>({ failed: false, opening: null })
+        : fetchOpening(this.game.name, this.game.instance),
       fetchTablebase(this.game.name, this.game.fen, this.game.instance.turn()),
     ]);
 
-    if (opening) this.game.opening = opening;
+    if (openingResult.failed) {
+      this.game.openingLookupDisabled = true;
+    } else if (openingResult.opening) {
+      this.game.opening = openingResult.opening;
+    }
     this.game.tablebase = tablebase;
 
     this.dirty.move = true;

--- a/src/services/lichess.ts
+++ b/src/services/lichess.ts
@@ -10,9 +10,11 @@ export type LichessTablebaseResponse = {
   category: string | null;
 };
 
-export async function fetchOpening(name: string, instance: Chess): Promise<string | null> {
+export type OpeningResult = { failed: boolean; opening: string | null };
+
+export async function fetchOpening(name: string, instance: Chess): Promise<OpeningResult> {
   const history = instance.history({ verbose: true });
-  if (!history.length) return null;
+  if (!history.length) return { failed: false, opening: null };
 
   const moves = history.map((move) => `${move.from}${move.to}`).join(',');
   const url = `https://explorer.lichess.org/masters?play=${moves}`;
@@ -35,14 +37,15 @@ export async function fetchOpening(name: string, instance: Chess): Promise<strin
       const { eco, name: openingName } = opening;
 
       logger.info(`Setting opening for game ${name} to ${eco} ${openingName}`, { port: name });
-      return `${eco} ${openingName}`;
+      return { failed: false, opening: `${eco} ${openingName}` };
     }
+
+    return { failed: false, opening: null };
   } catch (error) {
     logger.warn(`Error requesting opening for game ${name} @ ${url}`, { port: name });
     logger.error(error);
+    return { failed: true, opening: null };
   }
-
-  return null;
 }
 
 export async function fetchTablebase(name: string, fen: string, turn: ColorCode): Promise<string> {


### PR DESCRIPTION
## Problem

Games loaded mid-position (custom FEN) query the Lichess masters explorer with a move list that doesn't begin from startpos. The explorer returns a plaintext `bad request` body, so `response.json()` throws and a WARN+ERROR pair is logged **on every move** of that game:

```
[ WARN] [P16061] Error requesting opening for game 16061 @ https://explorer.lichess.org/masters?play=...
[ERROR] Unexpected token 'b', "bad reques"... is not valid JSON
```

## Change

- `fetchOpening` now returns an `OpeningResult` (`{ failed, opening }`) so the caller can distinguish a real failure from a normal out-of-book result.
- `ChessGame` gains an internal `openingLookupDisabled` flag, cleared on a new game (`reset()`).
- `onMove` skips the opening request when that flag is set **or** the game started from a non-standard FEN (`startFen !== null`), and flips the flag on the first failure.
- Tablebase lookups (which use the FEN directly) are unchanged and keep running in all cases.

## Verification

`npm run build` and `npm run lint` both pass.