### PR TITLE
feat: add no-op handlers for LOGON, FEATURE, and level commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ The frontend is TypeScript using jQuery and chessboardjs, bundled with Webpack.
 ### Key Classes
 
 - **Broadcast**: Core entity representing a single broadcast. Contains ChessGame, spectators Set, chat Array, menu Map. Sends LOGONv15 to connect to server.
-- **GameService**: Processes ~20 command types from the chess server via a `commandConfig` map. Each command has `split` (tokenize by whitespace) and `lowPrio` flags.
+- **GameService**: Processes ~22 command types from the chess server via a `commandConfig` map. Each command has `split` (tokenize by whitespace) and `lowPrio` flags.
 - **BroadcastState** (broadcast-state.ts): Serialization of broadcast state for Socket.IO emission.
 
 ### Routes
@@ -273,4 +273,5 @@ Environment variables:
 - **Webhook dispatch is fire-and-forget**: `WebhookManager.dispatch()` calls `sender.send()` without awaiting. `DiscordSender.send()` catches every error and always resolves, so a slow or failing webhook never blocks `onResult()` / the message batch. Do not `await` `dispatch()`.
 - **Webhook game-started dedup**: `GameService` fires one game-started event per game via a re-arm state machine (`gameStartArmed` / `startColorsSeen`). It is re-armed in `onResult()`. Connecting mid-game fires one game-started for the already-in-progress game — accepted.
 - **Webhook URL is a secret**: Discord webhook URLs embed a token. The admin table masks all but the last 8 chars, but the edit button still carries the full URL in a `data-url` attribute (admin page is basic-auth protected).
+- **No-op protocol commands**: `LOGON` (the `LOGON SUCCESSFUL` handshake reply), `FEATURE`, and `level` are recognized in the `Command` enum with no-op handlers (`() => [EmitType.UPDATE, false]`, same pattern as `PONG`). They are connection-time handshake/config lines the viewer derives nothing from (clocks come from `WTIME`/`BTIME`, not `level`); the handlers exist purely to suppress the `Unable to process <cmd>!` warning in `categorizeMessages`.
 - **No test infrastructure**: This project has no test runner or test files. Verification is done via `npm run build` (TypeScript + webpack) and manual testing.

--- a/src/game-service.ts
+++ b/src/game-service.ts
@@ -85,6 +85,11 @@ class GameService {
       [Command.MENU]: { fn: this.onMenu.bind(this), split: true, lowPrio: false },
       [Command.RESULT]: { fn: this.onResult.bind(this), split: false, lowPrio: false },
       [Command.FMR]: { fn: this.onFmr.bind(this), split: false, lowPrio: false },
+      // Recognized but intentionally ignored — connection-time handshake/config
+      // lines the viewer derives nothing from (see CLAUDE.md "No-op protocol commands").
+      [Command.LOGON]: { fn: () => [EmitType.UPDATE, false], split: false, lowPrio: false },
+      [Command.FEATURE]: { fn: () => [EmitType.UPDATE, false], split: false, lowPrio: false },
+      [Command.LEVEL]: { fn: () => [EmitType.UPDATE, false], split: false, lowPrio: false },
     };
   }
 

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -18,6 +18,9 @@ export enum Command {
   MENU = 'MENU',
   RESULT = 'result',
   FMR = 'FMR',
+  LOGON = 'LOGON',
+  FEATURE = 'FEATURE',
+  LEVEL = 'level',
 }
 
 export function splitOnCommand(line: string): [Command, string] {


### PR DESCRIPTION
## Summary

The TLCS server sends three connection-time handshake/config commands the viewer has no handler for. Each tripped the `Unable to process <cmd>!` warning in `categorizeMessages` (`src/game-service.ts`) on every connection:

- **`LOGON`** — the token from the server's `LOGON SUCCESSFUL` reply to our `LOGONv15` handshake
- **`FEATURE`** — XBoard/WinBoard-style feature/capability announcement
- **`level`** — XBoard time-control command (`level <moves> <base> <inc>`), lowercase on the wire

These are once-per-connection lines from TLCS's XBoard heritage that the viewer derives nothing from (clocks come from `WTIME`/`BTIME`, not `level`). Rather than handle them, this registers no-op handlers — matching the existing `PONG` pattern — to recognize the commands and suppress the warning noise.

## Changes

- `src/protocol.ts` — add `LOGON`, `FEATURE`, `LEVEL = 'level'` to the `Command` enum
- `src/game-service.ts` — add three no-op `commandConfig` entries (`() => [EmitType.UPDATE, false]`)
- `CLAUDE.md` — document the no-op commands in the Gotchas section; bump the GameService command-type count

The protocol delivery-mode lists in `CLAUDE.md` are intentionally left unchanged — they describe wire delivery (still accurate: `FEATURE`/`level` are ID-wrapped, `LOGON SUCCESSFUL` is unwrapped).

## Verification

- `npm run build` compiles clean — the `{ [key in Command]: ConfigItem }` mapped type guarantees no enum member is missing a handler
- `LOG_LEVEL=warn npm run dev-server` against the live broadcast: connection established and moves processed, with **zero `Unable to process LOGON/FEATURE/level` warnings** at handshake (previously all three fired on connect)