### PR TITLE
fix: push spectator-list changes live for browser viewers

### DIFF
--- a/src/socket-io-adapter.ts
+++ b/src/socket-io-adapter.ts
@@ -31,6 +31,7 @@ io.on('connection', (socket: Socket) => {
 
     socket.join(String(port));
     socket.emit('state', broadcast.toJSON(true));
+    emitSpectators(broadcast);
   });
 
   socket.on('chat', (msg: string) => {
@@ -49,6 +50,7 @@ io.on('connection', (socket: Socket) => {
     logger.info(`${originalUsername} changed their name to ${username}!`, { port: broadcast.port });
 
     socket.emit('state', broadcast.toJSON());
+    emitSpectators(broadcast);
   });
 
   socket.on('disconnect', () => {
@@ -60,12 +62,20 @@ io.on('connection', (socket: Socket) => {
     if (username) broadcast.spectators.delete(username);
 
     logger.info(`${username} has left from port ${broadcast.port}!`, { port: broadcast.port });
+    emitSpectators(broadcast);
   });
 });
 
 export function emitUpdate(port: number, data: BroadcastDelta): void {
   socketEmissions.inc({ port: String(port), type: 'update' });
   io.to(String(port)).emit(EmitType.UPDATE, data);
+}
+
+// Broadcast the current spectator list to everyone in the room. Used after
+// browser-driven changes (join/nick/disconnect) so already-connected clients
+// see viewers come and go without refreshing.
+function emitSpectators(broadcast: Broadcast): void {
+  emitUpdate(broadcast.port, { spectators: Array.from(broadcast.spectators) });
 }
 
 export function emitChat(port: number, messages: string[]): void {


### PR DESCRIPTION
## Problem

Closes #150.

A viewer reported that the connected-viewers list never updates without a manual refresh (their count jumped from 7 to 9 on reload). The TLCS-server-side spectator path (`ADDUSER`/`DELUSER` over UDP) already broadcasts live, but **browser viewers** joining/renaming/leaving via Socket.IO did not.

The `join`, `nick`, and `disconnect` handlers in `src/socket-io-adapter.ts` mutated the shared `broadcast.spectators` set but only sent a fresh `state` to the *acting* socket (and `disconnect` emitted nothing). Already-connected clients never learned about the change until they reloaded.

## Fix

Add a small `emitSpectators(broadcast)` helper that emits the current list to the whole room via the existing `emitUpdate`, and call it from all three handlers. No type or frontend changes — `buildDelta()` already serializes `delta.spectators` and the frontend already merges it in `applyDelta()` → `updateSpectators()`.

## Verification

- `npm run build` passes clean.
- Tested locally with `dev-server` + `dev-public` against broadcast `16061`, two browser tabs (Tester-A observing):
  - **Join:** Tester-B appeared in Tester-A's list with no refresh.
  - **Rename:** Tester-B → Tester-B-Renamed updated live.
  - **Leave:** closing Tester-B's tab dropped it live.
  - Regression: the TLCS-server user (`tlcv.net 1`) remained present throughout (unchanged path).