### PR TITLE
fix: stop wiping own chat when a user renames themselves

### DIFF
--- a/src/socket-io-adapter.ts
+++ b/src/socket-io-adapter.ts
@@ -49,7 +49,9 @@ io.on('connection', (socket: Socket) => {
 
     logger.info(`${originalUsername} changed their name to ${username}!`, { port: broadcast.port });
 
-    socket.emit('state', broadcast.toJSON());
+    // A rename only changes the spectator list; emitSpectators pushes that to
+    // the whole room (including this socket). Emitting full state here would
+    // re-seed chat history from an empty payload and wipe the user's chat box.
     emitSpectators(broadcast);
   });
 


### PR DESCRIPTION
## Problem

Renaming yourself wiped your own chat box. The `nick` handler emitted a full state snapshot to the renaming socket:

```ts
socket.emit('state', broadcast.toJSON());
```

`toJSON()` defaults `includeChat` to `false`, so the payload carried `chat: []`. The frontend `state` handler always re-seeds chat history — `setChat()` clears `#chat-box` then renders the payload — so an empty payload cleared the box on every name change.

This predates #151 (introduced in the delta-update refactor `17b72a0`, which switched the nick handler from `emit('update', ...)` to `emit('state', ...)`); it surfaced while testing the live spectator updates.

## Fix

A rename only changes the spectator list, and `emitSpectators()` (added in #151) already pushes that to the whole room including the renaming socket. The full-state emit was therefore both redundant and the cause of the wipe, so it's removed.

## Verification

Tested locally across two browser tabs on a live broadcast:

- **Buggy build** (line present): self-rename clears the chat box (1 → 0 messages).
- **Fixed build** (line removed): chat persists through a self-rename, and the live spectator update still propagates to other tabs (no refresh).