### PR TITLE
feat: make backend HTTP port configurable via PORT env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Copy to .env (gitignored, per worktree) and adjust as needed.
+
+# Backend HTTP/Socket.IO port (default 8080). Set a unique value per worktree
+# so multiple checkouts can run dev-server at the same time. Note: each worktree
+# must also point config/config.json at a DIFFERENT broadcast port (the local UDP
+# socket binds the broadcast port, and the TLCS server only streams to that port,
+# so two instances cannot share one broadcast on the same host).
+PORT=8080
+
+# Admin panel password (required)
+TLCV_PASSWORD=
+
+# Optional overrides (default to cwd-relative 'config' / 'pgns')
+# CONFIG_DIR=config
+# PGNS_DIR=pgns
+# LOG_LEVEL=info
+# LICHESS_OAUTH_TOKEN=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,8 +216,9 @@ The `kibitzers` array is optional. Each entry has an `id` (auto-assigned at star
 
 The `webhooks` array is also optional. Each entry has an `id` (auto-assigned if missing), a `type` (`"discord"` only for now), a `url`, an optional `name`, an optional `ports` array (empty/unset = all broadcasts), and an optional `events` array of `"game-started"` / `"game-finished"` (empty/unset = both).
 
-Environment variables:
+Environment variables (see `.env.example`; `.env` is gitignored and loaded via `dotenv`):
 - `TLCV_PASSWORD` - Admin panel password (required)
+- `PORT` - Backend HTTP/Socket.IO listen port (default: 8080). Set a unique value per worktree to run multiple instances side by side.
 - `CONFIG_DIR` - Config directory (default: "config")
 - `PGNS_DIR` - PGN output directory (default: "pgns")
 - `LICHESS_OAUTH_TOKEN` - Optional Lichess API bearer token for opening/tablebase lookups
@@ -274,4 +275,5 @@ Environment variables:
 - **Webhook game-started dedup**: `GameService` fires one game-started event per game via a re-arm state machine (`gameStartArmed` / `startColorsSeen`). It is re-armed in `onResult()`. Connecting mid-game fires one game-started for the already-in-progress game — accepted.
 - **Webhook URL is a secret**: Discord webhook URLs embed a token. The admin table masks all but the last 8 chars, but the edit button still carries the full URL in a `data-url` attribute (admin page is basic-auth protected).
 - **No-op protocol commands**: `LOGON` (the `LOGON SUCCESSFUL` handshake reply), `FEATURE`, and `level` are recognized in the `Command` enum with no-op handlers (`() => [EmitType.UPDATE, false]`, same pattern as `PONG`). They are connection-time handshake/config lines the viewer derives nothing from (clocks come from `WTIME`/`BTIME`, not `level`); the handlers exist purely to suppress the `Unable to process <cmd>!` warning in `categorizeMessages`.
+- **UDP local bind = broadcast port is mandatory**: `UdpTransport` binds the local socket to the broadcast port (`udp-transport.ts`). This is required, not a convention: the TLCS server streams the broadcast to `clientIP:<broadcast port>` and ignores the source port of our `LOGONv15` (verified empirically — a LOGON sent from a different source port still has its data delivered to the broadcast port). Consequences: you cannot bind an ephemeral local port and still receive data, and two instances on the same host cannot watch the *same* broadcast (both need that port → `EADDRINUSE`). To run multiple worktrees, point each `config/config.json` at a **different** broadcast port.
 - **No test infrastructure**: This project has no test runner or test files. Verification is done via `npm run build` (TypeScript + webpack) and manual testing.

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,5 +52,6 @@ io.attach(server);
 
   kibitzerManager.start();
 
-  server.listen(8080, () => logger.info('Started listening on port 8080!'));
+  const port = Number(process.env.PORT) || 8080;
+  server.listen(port, () => logger.info(`Started listening on port ${port}!`));
 })();

--- a/src/transport/udp-transport.ts
+++ b/src/transport/udp-transport.ts
@@ -24,6 +24,10 @@ export class UdpTransport {
     this.socket.on('listening', this.onListening.bind(this));
     this.socket.on('message', this.onMessage.bind(this));
 
+    // The local socket MUST bind the broadcast port: the TLCS server streams the
+    // broadcast to clientIP:<broadcast port> and ignores the source port of our
+    // LOGON entirely (verified empirically). Binding any other port receives
+    // nothing. This is why two instances on one host cannot share a broadcast.
     this.socket.bind(port);
   }
 


### PR DESCRIPTION
## What

Adds a `PORT` environment variable (default `8080`) for the backend HTTP/Socket.IO server, so the dev-server can run from multiple git worktrees simultaneously without colliding on port 8080. Production sets no env var, so it's unchanged.

Also documents the worktree workflow and adds a committed `.env.example`.

## Why

Running a second checkout (e.g. a git worktree) hit two collisions:
1. **Backend HTTP port** — hardcoded `8080`. Fixed here via `PORT`.
2. **Broadcast UDP port** — the local UDP socket *must* bind the broadcast port. While investigating I confirmed empirically that the TLCS server streams the broadcast to `clientIP:<broadcast port>` and **ignores the source port** of our `LOGON` (a LOGON sent from a different source port still had its data delivered to a socket bound to the broadcast port). So the bind is mandatory, an ephemeral local bind receives nothing, and two instances on one host can't share a broadcast.

The workable model is therefore **one broadcast per worktree**: each worktree points `config/config.json` at a different broadcast port. `config/`, `pgns/`, and `build/` are already cwd-relative, so they isolate per worktree automatically.

## Changes

- `src/main.ts` — `server.listen(Number(process.env.PORT) || 8080, …)`
- `src/transport/udp-transport.ts` — comment documenting why `socket.bind(port)` is mandatory (no behavior change)
- `.env.example` — new committed template (`PORT` + existing vars)
- `CLAUDE.md` — `PORT` env var entry + gotcha recording the fixed-port/worktree constraint

## Verification

- `npm run build` compiles clean.
- Ran the compiled server against a live broadcast on a dev host: 160–170+ packets/20s on the fixed-port path; `PORT=8099` confirmed the listener honors the env var.