### PR TITLE
fix(broadcasts): stop home cards overflowing viewport on mobile (#154)

### DIFF
--- a/public/css/_broadcasts.scss
+++ b/public/css/_broadcasts.scss
@@ -14,6 +14,7 @@
 
 .broadcast-card {
   display: block;
+  min-width: 0; // allow the grid item to shrink below its min-content (fixes #154)
   background: var(--surfaceColor);
   border: 1px solid var(--surfaceColorHover);
   border-radius: 8px;


### PR DESCRIPTION
Closes #154.

## Problem

On narrow viewports the home page broadcast cards don't shrink to fit, so the page scrolls horizontally (the issue measured ~531px rendered at a 390px viewport). Clocks, eval bars, and opening names get clipped off the right edge.

## Root cause

The issue's suggested fixes (`min-width: 0` on `.card-info`, name truncation, `1fr` mobile grid) were **already in `main`** from earlier commits (`e2d6efe`, `c30098e`). The real remaining cause was one level up:

`.broadcast-card` is a **CSS Grid item** that still had the default `min-width: auto`, which forbids shrinking below its min-content. With long engine/opening names, the card's min-content stretched the `1fr` mobile track far past the viewport — the issue's own numbers confirm this (the track stretched to 515px and `.card-info` received a 407px *share* of it). `min-width: 0` on the inner flex child can't help while the outer grid item is still allowed to grow.

## Fix

One line — `min-width: 0` on the grid item so it can shrink to the `1fr` track, letting the already-present flex `min-width: 0` + truncation on `.card-info` do their job. Placed in the base rule (not the responsive partial) because it's correct at all widths and inert on desktop, where tracks are always ≥420px.

## Verification

Playwright (Chromium) against a live broadcast:

- **Direct before/after at 390px with long names injected:** `min-width: auto` → document **763px wide, overflow**; `min-width: 0` → **390px, no overflow**, name truncates with ellipsis.
- No horizontal overflow at **320 / 390 / 767px** (all stress-tested with long names).
- **1280px desktop unchanged** — 2-column grid (592px cards) intact; the fix is inert above 420px tracks.
- `npm run prebuild` + backend `tsc` compile clean.

Frontend-only change → UI-only deploy (no service restart).