### PR TITLE
fix(a11y): clean accessible names for broadcast cards, hide decorative boards

### DIFF
--- a/views/pages/broadcasts.ejs
+++ b/views/pages/broadcasts.ejs
@@ -49,11 +49,16 @@
             'K': 'wK', 'Q': 'wQ', 'R': 'wR', 'B': 'wB', 'N': 'wN', 'P': 'wP',
             'k': 'bK', 'q': 'bQ', 'r': 'bR', 'b': 'bB', 'n': 'bN', 'p': 'bP'
           };
+
+          function cardLabel(b) {
+            var prefix = b.site ? b.site + ' — ' : '';
+            return prefix + b.white + ' vs ' + b.black + ', move ' + b.moveCount;
+          }
         %>
         <% broadcasts.forEach(function(broadcast, idx) { %>
-        <a href="/<%= broadcast.port %>" class="broadcast-card<%= idx === 0 ? ' featured' : '' %>">
+        <a href="/<%= broadcast.port %>" class="broadcast-card<%= idx === 0 ? ' featured' : '' %>" aria-label="<%= cardLabel(broadcast) %>">
           <div class="card-inner">
-            <div class="mini-board">
+            <div class="mini-board" aria-hidden="true">
               <%
                 var ranks = broadcast.fen.split(' ')[0].split('/');
                 ranks.forEach(function(rank, rankIdx) {
@@ -75,7 +80,7 @@
                       var light = (rankIdx + fileIdx) % 2 === 0;
                 %>
                 <div class="sq <%= light ? 'sq-l' : 'sq-d' %>">
-                  <img src="/img/<%= pieceMap[ch] %>.svg" alt="<%= ch %>" />
+                  <img src="/img/<%= pieceMap[ch] %>.svg" alt="" />
                 </div>
                 <%
                       fileIdx++;

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -12,8 +12,8 @@
     <div class="container">
       <div class="main-layout">
         <div id="board-container">
-          <canvas id="arrow-board" height="2400" width="2400"></canvas>
-          <div id="board"></div>
+          <canvas id="arrow-board" height="2400" width="2400" aria-hidden="true"></canvas>
+          <div id="board" aria-hidden="true"></div>
           <div id="board-footer">
             <div id="kibitzer-bar" hidden>
               <span id="kibitzer-name"></span>

--- a/views/partials/info-card.ejs
+++ b/views/partials/info-card.ejs
@@ -31,6 +31,6 @@
       </div>
     </div>
   </div>
-  <div id="<%= color %>-pv-board" class="info-board">
+  <div id="<%= color %>-pv-board" class="info-board" aria-hidden="true">
   </div>
 </div>


### PR DESCRIPTION
## Problem

On the home/broadcasts listing, each card rendered its mini chess board as ~32 individual `<img>` elements with single-letter `alt` text (`"b"`, `"r"`, `"p"`, `"N"`…), and that board sits **inside the card's `<a>` link**. The link's accessible name is computed from those alts first, so a screen-reader user heard a meaningless stream of ~32 junk letters before any real info — on every card.

## Fix

All changes are template-only (EJS); no TS/build changes.

- **`views/pages/broadcasts.ejs`** (primary): add an `aria-label` on the card `<a>` built from existing data (`"<site> — <white> vs <black>, move <n>"`), mark the decorative `.mini-board` `aria-hidden="true"`, and set the piece `<img>` `alt=""`.
- **`views/pages/index.ejs`**: mark the in-game `#board` and `#arrow-board` canvas `aria-hidden="true"`. chessboardjs only replaces the container's *contents* (`containerEl.html(...)` once, then `boardEl.html(...)` on the inner element), so the attribute persists across re-renders.
- **`views/partials/info-card.ejs`**: mark the decorative PV boards (`#*-pv-board`) `aria-hidden="true"`.

The boards here are decorative — game state remains available to assistive tech via the move list and the text-based player info cards — so hiding them is simpler and correct (no per-square ARIA needed).

## Verification

Ran the server against live broadcast `16071` (Catalyst v3.0.0 vs Stockfish 6 64 POPCNT):

- **Home page** — `curl`'d the fully server-rendered HTML: card `<a aria-label="Catalyst Gauntlet — Catalyst v3.0.0 vs Stockfish 6 64 POPCNT, move 2">`, `.mini-board` `aria-hidden="true"`, and all rendered piece imgs `alt=""`.
- **Game page** — confirmed in the live DOM *after* chessboardjs rendered all 25 pieces that `#board` still carries `aria-hidden="true"`, with the arrow canvas and both PV boards hidden and all piece alts empty.
- `npm run build` passes.