### PR TITLE
feat: persist latest tournament results on game finish

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -134,3 +134,12 @@ export type GameRecord = {
 };
 
 export type StoredGameMeta = SerializedGame & { result: string };
+
+export type StoredTournamentResults = {
+  site: string;
+  port: number;
+  updated: string; // ISO 8601 timestamp
+  results: string; // raw accumulated CT text dump
+  parsedResults: ParsedResults | null;
+  parsedGames: GameRecord[];
+};

--- a/src/game-service.ts
+++ b/src/game-service.ts
@@ -7,6 +7,7 @@ import { fetchOpening, fetchTablebase } from './services/lichess.js';
 import type { OpeningResult } from './services/lichess.js';
 import { savePgn } from './services/pgn.js';
 import { saveGameMeta, invalidate as invalidateMetaCache } from './services/game-meta.js';
+import { saveTournamentResults } from './services/tournament-results.js';
 import { invalidate as invalidatePgnCache } from './services/pgn-cache.js';
 import { Command, splitOnCommand } from './protocol.js';
 import { EmitType } from './socket-io-adapter.js';
@@ -393,6 +394,10 @@ class GameService {
       if (games.length > 0) {
         this.broadcast.parsedGames = games;
         this.broadcast.currentGameNumber = games[0].gameNumber + 1;
+
+        // Persist the latest standings + schedule (fixed filename, overwritten each dump).
+        // Fire-and-forget: saveTournamentResults catches all errors internally.
+        saveTournamentResults(this.broadcast);
       }
       this.gamesParseTimer = null;
     }, 100);

--- a/src/services/tournament-results.ts
+++ b/src/services/tournament-results.ts
@@ -7,25 +7,27 @@ import { logger, siteSlug as toSiteSlug } from '../util/index.js';
 const RESULTS_FILENAME = 'tournament-results.json';
 
 export async function saveTournamentResults(broadcast: Broadcast): Promise<void> {
-  const { site } = broadcast.game;
-
-  const slug = toSiteSlug(site);
-  const dirname = `pgns/${slug}`;
-  const filepath = `${dirname}/${RESULTS_FILENAME}`;
-
-  const data: StoredTournamentResults = {
-    site,
-    port: broadcast.port,
-    updated: new Date().toISOString(),
-    results: broadcast.results,
-    parsedResults: broadcast.parsedResults,
-    parsedGames: broadcast.parsedGames ?? [],
-  };
-
+  // Fire-and-forget from the message loop, so the whole body is guarded — a throw
+  // anywhere (slug/path construction included) must never become an unhandled rejection.
   try {
+    const { site } = broadcast.game;
+
+    const slug = toSiteSlug(site);
+    const dirname = `pgns/${slug}`;
+    const filepath = `${dirname}/${RESULTS_FILENAME}`;
+
+    const data: StoredTournamentResults = {
+      site,
+      port: broadcast.port,
+      updated: new Date().toISOString(),
+      results: broadcast.results,
+      parsedResults: broadcast.parsedResults,
+      parsedGames: broadcast.parsedGames ?? [],
+    };
+
     await mkdirp(dirname);
     await fs.writeFile(filepath, JSON.stringify(data));
   } catch (error) {
-    logger.error(`Unable to write tournament results to ${filepath}! - ${error}`, { port: broadcast.port });
+    logger.error(`Unable to write tournament results! - ${error}`, { port: broadcast.port });
   }
 }

--- a/src/services/tournament-results.ts
+++ b/src/services/tournament-results.ts
@@ -1,0 +1,31 @@
+import fs from 'fs/promises';
+import { mkdirp } from 'mkdirp';
+import type { Broadcast } from '../broadcast.js';
+import type { StoredTournamentResults } from '../../shared/types.js';
+import { logger, siteSlug as toSiteSlug } from '../util/index.js';
+
+const RESULTS_FILENAME = 'tournament-results.json';
+
+export async function saveTournamentResults(broadcast: Broadcast): Promise<void> {
+  const { site } = broadcast.game;
+
+  const slug = toSiteSlug(site);
+  const dirname = `pgns/${slug}`;
+  const filepath = `${dirname}/${RESULTS_FILENAME}`;
+
+  const data: StoredTournamentResults = {
+    site,
+    port: broadcast.port,
+    updated: new Date().toISOString(),
+    results: broadcast.results,
+    parsedResults: broadcast.parsedResults,
+    parsedGames: broadcast.parsedGames ?? [],
+  };
+
+  try {
+    await mkdirp(dirname);
+    await fs.writeFile(filepath, JSON.stringify(data));
+  } catch (error) {
+    logger.error(`Unable to write tournament results to ${filepath}! - ${error}`, { port: broadcast.port });
+  }
+}


### PR DESCRIPTION
## What

Records the **latest** tournament results (standings table + games schedule) to a single JSON file in the same `pgns/{siteSlug}/` directory as the existing per-game `.meta.json` / `.pgn` snapshots, so a tournament's table and schedule can be reconstructed retroactively from disk.

It's *latest*, not point-in-time: a fixed filename (`tournament-results.json`) overwritten on each completed crosstable (CT) dump.

## Why

Today `parsedResults` (standings) and `parsedGames` (schedule) live only in memory on the `Broadcast` and are served live via `/:port/result-table/json` and `/:port/games/json`. They're lost when a broadcast closes, reconnects, or a port is reused for a new tournament — per-game move snapshots survive, but the tournament-level table/schedule do not.

## How

- New service `src/services/tournament-results.ts` — `saveTournamentResults(broadcast)`, mirroring the `game-meta.ts` pattern (`mkdirp` + `writeFile`, try/catch + `logger.error`). Writes `pgns/{siteSlug}/tournament-results.json`.
- New shared type `StoredTournamentResults` (`shared/types.ts`): `site`, `port`, ISO `updated`, raw `results` text, `parsedResults`, bare `parsedGames`.
- Wired into the `onCT` debounce callback in `src/game-service.ts` (fire-and-forget).

**Why the `onCT` debounce, not `onResult`:** `onResult` calls `reloadResults()` to request a fresh `RESULTTABLE`, but at that instant the parsed state is still pre-finish. The up-to-date table (including the just-finished game) only lands when that dump finishes parsing in the debounce. This also writes once at startup, which is fine under "latest" semantics.

The fixed filename intentionally matches neither FileCache regex (`/^(\d+)_.+\.meta\.json$/i`, `/^(\d+)_.+\.pgn$/i`), so it never shows up as a phantom game in `/:port/games/json`.

**Scope: write-only** — no new route, no frontend wiring.

## Verification

- `tsc -p tsconfig.backend.json` clean for project source; ESLint clean on all three files. (Note: a full `npm run build` currently fails locally on a pre-existing `@types/ssh2` nested-`@types/node` conflict, identical on `main` and unrelated to this change.)
- Ran `dev-server` against 8 live gauntlet broadcasts (~7 min):
  - **Startup:** 8 `tournament-results.json` files written with correct shape (e.g. Winter Gauntlet: 11 standings rows, totalGames 66, 62 game records).
  - **On game finish:** confirmed rewrites on two independent tournaments — Winter Gauntlet (`parsedGames` 62→67) and Stash 4CPU Gauntlet (131→147), each with an advanced `updated` timestamp and the finished game included.
  - **0** `Unable to write tournament results` errors; **0** uncaught/fatal errors.