### PR TITLE
feat(theme): separate board theme from page theme

### DIFF
--- a/public/css/_theme-modal.scss
+++ b/public/css/_theme-modal.scss
@@ -50,6 +50,20 @@
   }
 }
 
+.theme-section {
+  & + & {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid var(--surfaceColorHover);
+  }
+}
+
+.theme-section-title {
+  margin: 0 0 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
 .theme-note {
   margin: 12px 0 0;
   font-size: 0.8rem;

--- a/public/js/components/theme/index.ts
+++ b/public/js/components/theme/index.ts
@@ -36,8 +36,9 @@ function alphaSuffix(value: string): string {
 }
 
 // ---- derived colors --------------------------------------------------------
-// Hover and highlight colors are auto-calculated from the essentials so a custom
-// palette stays coherent without the user hand-tuning them.
+// Hover colors are auto-calculated from the page essentials so a custom palette
+// stays coherent without the user hand-tuning them. Board colors (including the
+// move highlight) are independent and never derived.
 
 interface RGBA {
   r: number;
@@ -88,7 +89,7 @@ function shadeForContrast(color: RGBA, bg: RGBA, amount = 0.2): RGBA {
   };
 }
 
-// Returns a new map with hover/highlight tokens recomputed from the essentials.
+// Returns a new map with the page hover tokens recomputed from the essentials.
 function deriveDependents(colors: ThemeColors): ThemeColors {
   const bg = parseColor(colors['--backgroundColor']);
   const primary = parseColor(colors['--primaryColor']);
@@ -103,9 +104,6 @@ function deriveDependents(colors: ThemeColors): ThemeColors {
     hover.a = luminance(bg) < 0.5 ? '' : '40';
     next['--surfaceColorHover'] = rgbaToString(hover);
   }
-  // Move-highlight follows the accent so it stays coherent; keep a translucent
-  // overlay (matches the presets' authored ~6b alpha).
-  if (primary) next['--highlightColor'] = rgbaToString({ ...primary, a: '6b' });
   return next;
 }
 
@@ -122,8 +120,8 @@ function loadCustomColors(base: PresetName): ThemeColors {
 }
 
 function resolveColors(theme: ThemeName): ThemeColors {
-  // Presets keep their hand-authored hover/highlight values; custom palettes
-  // derive them from the essentials so they always stay coherent.
+  // Presets keep their hand-authored hover values; custom palettes derive them
+  // from the page essentials so they always stay coherent.
   return theme === 'custom' ? deriveDependents(loadCustomColors(basePreset)) : { ...PRESETS[theme] };
 }
 
@@ -176,7 +174,7 @@ function setColor(token: ThemeTokenKey, inputHex: string) {
     currentTheme = 'custom';
   }
   currentColors[token] = inputHex + alphaSuffix(currentColors[token]);
-  // Recompute hover/highlight from the (possibly just-changed) essentials.
+  // Recompute page hover states from the (possibly just-changed) essentials.
   currentColors = deriveDependents(currentColors);
   applyColors(currentColors);
   persist();
@@ -191,15 +189,19 @@ export function getTheme(): ThemeName {
 // ---- editor UI -------------------------------------------------------------
 
 function buildRows() {
-  const groups: Record<'essential' | 'advanced', JQuery<HTMLElement>> = {
-    essential: $('#theme-essential'),
-    advanced: $('#theme-advanced'),
-  };
-  if (!groups.essential.length) return;
-  groups.essential.empty();
-  groups.advanced.empty();
+  // One container per (section, tier); ids match the markup in theme-modal.ejs.
+  const containers = new Map<string, JQuery<HTMLElement>>();
+  let anyFound = false;
+  TOKENS.forEach(({ section, tier }) => {
+    const id = `${section}-${tier}`;
+    if (containers.has(id)) return;
+    const el = $(`#theme-${id}`);
+    if (el.length) anyFound = true;
+    containers.set(id, el.empty());
+  });
+  if (!anyFound) return;
 
-  TOKENS.forEach(({ key, label, group }) => {
+  TOKENS.forEach(({ key, label, section, tier }) => {
     const inputId = `theme-input-${key}`;
     const row = $(`
       <div class="theme-row">
@@ -208,7 +210,7 @@ function buildRows() {
         <input type="color" id="${inputId}" class="theme-color-input" data-token="${key}" />
       </div>
     `);
-    groups[group].append(row);
+    containers.get(`${section}-${tier}`)?.append(row);
   });
 
   $('.theme-color-input').on('input', function () {

--- a/public/js/components/theme/presets.ts
+++ b/public/js/components/theme/presets.ts
@@ -34,38 +34,47 @@ export type ThemeTokenKey =
 
 export type ThemeColors = Record<ThemeTokenKey, string>;
 
-export type TokenGroup = 'essential' | 'advanced';
+// Tokens are organized along two orthogonal dimensions: which part of the UI
+// they theme (`section`) and how prominent they are in the editor (`tier`). The
+// editor renders one block per section with the advanced tier behind a collapse.
+export type TokenSection = 'page' | 'board';
+export type TokenTier = 'essential' | 'advanced';
 
 export interface TokenMeta {
   key: ThemeTokenKey;
   label: string;
-  group: TokenGroup;
+  section: TokenSection;
+  tier: TokenTier;
 }
 
-// The curated subset of tokens exposed in the editor.
+// The curated subset of tokens exposed in the editor, grouped by section so the
+// chess board's colors are fully separate from the rest of the page.
 //
 // Tokens omitted here are NOT user-editable, for two reasons:
-//   - Derived (see DERIVED_TOKENS / deriveDependents in ./index.ts): for custom
-//     themes these are auto-calculated from the essentials so hover/highlight
-//     always stay coherent with the chosen accent/surface — `--primaryColorHover`,
-//     `--surfaceColorHover`, `--highlightColor`.
+//   - Derived (see deriveDependents in ./index.ts): for custom themes these are
+//     auto-calculated from the page essentials so hover states always stay
+//     coherent with the chosen accent/surface — `--primaryColorHover`,
+//     `--surfaceColorHover`.
 //   - Preset-only / niche: `--cardTextColor`, `--pieceWhiteColor`,
 //     `--pieceBlackColor`, `--kibitzerColor`.
 export const TOKENS: TokenMeta[] = [
-  { key: '--primaryColor', label: 'Accent', group: 'essential' },
-  { key: '--backgroundColor', label: 'Background', group: 'essential' },
-  { key: '--surfaceColor', label: 'Surface', group: 'essential' },
-  { key: '--textColor', label: 'Text', group: 'essential' },
-  { key: '--boardLight', label: 'Board — light squares', group: 'essential' },
-  { key: '--boardDark', label: 'Board — dark squares', group: 'essential' },
-  { key: '--secondaryColor', label: 'Secondary accent', group: 'advanced' },
-  { key: '--graphWhiteColor', label: 'Graph — white', group: 'advanced' },
-  { key: '--graphBlackColor', label: 'Graph — black', group: 'advanced' },
-  { key: '--evalBarWhite', label: 'Eval bar — white', group: 'advanced' },
-  { key: '--evalBarBlack', label: 'Eval bar — black', group: 'advanced' },
-  { key: '--whiteArrowColor', label: 'White move arrow', group: 'advanced' },
-  { key: '--blackArrowColor', label: 'Black move arrow', group: 'advanced' },
-  { key: '--kibitzerArrowColor', label: 'Kibitzer arrow', group: 'advanced' },
+  // Page
+  { key: '--primaryColor', label: 'Accent', section: 'page', tier: 'essential' },
+  { key: '--backgroundColor', label: 'Background', section: 'page', tier: 'essential' },
+  { key: '--surfaceColor', label: 'Surface', section: 'page', tier: 'essential' },
+  { key: '--textColor', label: 'Text', section: 'page', tier: 'essential' },
+  { key: '--secondaryColor', label: 'Secondary accent', section: 'page', tier: 'advanced' },
+  { key: '--graphWhiteColor', label: 'Graph — white', section: 'page', tier: 'advanced' },
+  { key: '--graphBlackColor', label: 'Graph — black', section: 'page', tier: 'advanced' },
+  { key: '--evalBarWhite', label: 'Eval bar — white', section: 'page', tier: 'advanced' },
+  { key: '--evalBarBlack', label: 'Eval bar — black', section: 'page', tier: 'advanced' },
+  // Board
+  { key: '--boardLight', label: 'Light squares', section: 'board', tier: 'essential' },
+  { key: '--boardDark', label: 'Dark squares', section: 'board', tier: 'essential' },
+  { key: '--highlightColor', label: 'Last-move highlight', section: 'board', tier: 'essential' },
+  { key: '--whiteArrowColor', label: 'White move arrow', section: 'board', tier: 'advanced' },
+  { key: '--blackArrowColor', label: 'Black move arrow', section: 'board', tier: 'advanced' },
+  { key: '--kibitzerArrowColor', label: 'Kibitzer arrow', section: 'board', tier: 'advanced' },
 ];
 
 export const PRESETS: Record<PresetName, ThemeColors> = {

--- a/views/partials/theme-modal.ejs
+++ b/views/partials/theme-modal.ejs
@@ -13,14 +13,24 @@
       <label><input type="radio" name="theme-preset" value="custom" /> Custom</label>
     </div>
 
-    <div id="theme-essential" class="theme-rows"></div>
+    <section class="theme-section">
+      <h4 class="theme-section-title">Page</h4>
+      <div id="theme-page-essential" class="theme-rows"></div>
+      <p class="theme-note">Hover colors are calculated automatically from your accent, surface, and background.</p>
+      <details class="theme-advanced">
+        <summary>Advanced page colors</summary>
+        <div id="theme-page-advanced" class="theme-rows"></div>
+      </details>
+    </section>
 
-    <p class="theme-note">Hover and highlight colors are calculated automatically from your accent, surface, and background.</p>
-
-    <details class="theme-advanced">
-      <summary>Advanced colors</summary>
-      <div id="theme-advanced" class="theme-rows"></div>
-    </details>
+    <section class="theme-section">
+      <h4 class="theme-section-title">Board</h4>
+      <div id="theme-board-essential" class="theme-rows"></div>
+      <details class="theme-advanced">
+        <summary>Advanced board colors</summary>
+        <div id="theme-board-advanced" class="theme-rows"></div>
+      </details>
+    </section>
 
     <div class="theme-modal-footer">
       <button id="theme-reset" type="button">Reset to preset</button>


### PR DESCRIPTION
## Summary

Makes the chess **board** a fully independent theming module from the **rest of the page**, under the same Light/Dark/Custom selector.

Previously the board's last-move highlight (`--highlightColor`) was *derived from* the page Accent (`--primaryColor`) in `deriveDependents()`. Consequences:
- Changing the page accent silently recolored the board.
- A user who hand-picked a board highlight had it **clobbered** the moment they edited any other token (because `setColor()` always re-runs `deriveDependents()`).

Now page and board tokens share nothing, and editing one never affects the other.

## Changes

- **`presets.ts`** — replace the flat `TokenGroup` (`essential`/`advanced`) with two orthogonal dimensions: `section` (`'page' | 'board'`) × `tier` (`'essential' | 'advanced'`). Regroup `TOKENS` by section and promote `--highlightColor` to an editable **Board** token. Preset color *values are unchanged* (the authored `#52b1dc6b` / `#99d69e66` highlights simply become editable instead of derived).
- **`theme/index.ts`** — drop the `--highlightColor` derivation from `deriveDependents()` (only the page hover tokens `--primaryColorHover` / `--surfaceColorHover` derive now); render the editor into per-`section`/`tier` containers.
- **`theme-modal.ejs`** — split the editor into labeled **Page** and **Board** sections, each with its own collapsed "Advanced" group; update the auto-calc note (hover only).
- **`_theme-modal.scss`** — add `.theme-section` heading + divider styling.

Scope is board-only: graphs remain part of the page theme (the kibitzer eval line still uses `--primaryColor`). `--highlightColor` keeps its name to avoid churn across the SCSS fallback / consumers.

## Verification

Frontend build (`npm run prebuild`) compiles clean. Tested end-to-end with Playwright against a live broadcast:

- Modal shows separate **Page** and **Board** sections, each with its own Advanced collapse; last-move highlight is an editable Board token.
- Editing the page **Accent** no longer changes the board highlight; page hover states still re-derive correctly.
- Editing the **board highlight** persists across a later unrelated page edit (the old clobbering bug is gone), with its alpha preserved and saved to `tlcv.customTheme`.
- Light/Dark presets render their hand-authored highlights; preset switching works.
- No theme-related JS console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)