### PR TITLE
feat: previous broadcasts (tournament archive)

### DIFF
--- a/public/css/_broadcasts.scss
+++ b/public/css/_broadcasts.scss
@@ -207,3 +207,59 @@
   padding: 40px;
   color: var(--textColor);
 }
+
+// Previous broadcasts (archive)
+.archive-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(280px, 100%), 1fr));
+  gap: 12px;
+  padding: 16px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.archive-card {
+  display: block;
+  min-width: 0;
+  background: var(--surfaceColor);
+  border: 1px solid var(--surfaceColorHover);
+  border-radius: 8px;
+  padding: 12px 14px;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.2s, box-shadow 0.2s, border-color 0.2s, transform 0.2s;
+
+  &:link,
+  &:visited {
+    text-decoration: none;
+    color: inherit;
+  }
+
+  &:hover {
+    background: var(--surfaceColorHover);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    transform: scale(1.02);
+  }
+}
+
+.archive-title {
+  font-weight: 600;
+  font-size: 0.95em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.archive-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 6px;
+  font-size: 0.8em;
+  color: var(--textColor);
+}
+
+.archive-date {
+  font-family: monospace;
+}

--- a/public/js/components/games/index.ts
+++ b/public/js/components/games/index.ts
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import type { GameRecord, StoredGameMeta } from '../../../../shared/types';
 import { on, emit } from '../../events/index';
-import { getPort } from '../../utils/url';
+import { apiBase, isArchive } from '../../utils/url';
 
 const DOWNLOAD_ICON =
   '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>';
@@ -60,7 +60,7 @@ function renderGames(games: GameRecord[]) {
 
 function loadReplay(gameNumber: number) {
   $.ajax({
-    url: `/${getPort()}/games/${gameNumber}/meta`,
+    url: `${apiBase()}/games/${gameNumber}/meta`,
     method: 'GET',
     dataType: 'json',
   })
@@ -79,7 +79,7 @@ function fetchAndRender() {
   $container.html('<p class="games-loading">Loading games...</p>');
 
   $.ajax({
-    url: `/${getPort()}/games/json`,
+    url: `${apiBase()}/games/json`,
     method: 'GET',
     dataType: 'json',
   })
@@ -92,8 +92,28 @@ function fetchAndRender() {
     });
 }
 
+// Archive pages have no live feed, so open them on the most recent finished game
+// (highest game number with a saved meta sidecar) to avoid landing on a blank board.
+function autoLoadLatest() {
+  $.ajax({
+    url: `${apiBase()}/games/json`,
+    method: 'GET',
+    dataType: 'json',
+  }).done((data: GameRecord[]) => {
+    const latest = data
+      .filter((g) => g.metaUrl)
+      .reduce<GameRecord | null>((best, g) => (!best || g.gameNumber > best.gameNumber ? g : best), null);
+    if (latest) loadReplay(latest.gameNumber);
+  });
+}
+
 export function init() {
   on('tab:change', ({ tab }) => {
     if (tab === 'games') fetchAndRender();
   });
+
+  if (isArchive()) {
+    fetchAndRender();
+    autoLoadLatest();
+  }
 }

--- a/public/js/components/replay/index.ts
+++ b/public/js/components/replay/index.ts
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import type { StoredGameMeta } from '../../../../shared/types';
 import { on, emit } from '../../events/index';
 import type { GameEventData } from '../../events/index';
+import { isArchive } from '../../utils/url';
 
 let replaying = false;
 let lastLiveData: GameEventData | null = null;
@@ -67,6 +68,11 @@ function exitReplay() {
 }
 
 function injectBanner() {
+  // The banner is the "return to the live game" affordance. Archive pages have no
+  // live game — every view is a replay of a saved game, and switching games happens
+  // via the Games list — so there's no banner to inject.
+  if (isArchive()) return;
+
   const banner = $('<div id="replay-banner" hidden>')
     .append($('<span class="replay-title">'))
     .append(

--- a/public/js/components/results/index.ts
+++ b/public/js/components/results/index.ts
@@ -2,7 +2,7 @@
 import $ from 'jquery';
 import type { H2HCell, StandingsRow } from '../../../../shared/types';
 import { on } from '../../events/index';
-import { getPort } from '../../utils/url';
+import { apiBase } from '../../utils/url';
 
 function renderH2HCell(cell: H2HCell, isSelf: boolean) {
   const $td = $('<td>').addClass('results-h2h-cell');
@@ -69,7 +69,7 @@ function fetchAndRender() {
   $container.html('<p class="results-loading">Loading results...</p>');
 
   $.ajax({
-    url: `/${getPort()}/result-table/json`,
+    url: `${apiBase()}/result-table/json`,
     method: 'GET',
     dataType: 'json',
   })

--- a/public/js/components/tabs/index.ts
+++ b/public/js/components/tabs/index.ts
@@ -22,6 +22,10 @@ function switchTab(tab: string) {
 }
 
 export function init() {
+  // Seed from the server-rendered default so archive mode (no Chat tab) can start
+  // on a different tab; falls back to 'chat' for the live page.
+  activeTab = $('#chat-area').attr('data-active-tab') || 'chat';
+
   $('#tab-bar').on('click', '.tab-btn', function handleTabClick() {
     const tab = $(this).attr('data-tab');
     if (tab && tab !== activeTab) {

--- a/public/js/index.ts
+++ b/public/js/index.ts
@@ -20,16 +20,20 @@ import { init as initFocus } from './components/focus/index';
 import { init as initFlip } from './components/flip/index';
 import { init as initSounds } from './components/sounds/index';
 import { chatHeight, updateLayout } from './components/board/resize';
-import { getPort } from './utils/url';
+import { getPort, isArchive } from './utils/url';
 
-// Get port from URL
-const port = getPort();
+// Archive (previous broadcast) pages are read-only and disk-backed: no live socket,
+// no chat. The games component drives the board via replay events instead.
+const archive = isArchive();
+
+// Get port from URL (live mode only)
+const port = archive ? 0 : getPort();
 
 // Initialize socket
 const socket = io({ autoConnect: false });
 
-// Pass socket to chat component
-setSocket(socket);
+// Pass socket to chat component (live mode only)
+if (!archive) setSocket(socket);
 
 // Cached state for delta merging
 let cachedState: GameEventData | null = null;
@@ -89,7 +93,7 @@ function init() {
   initGames();
   initReplay();
   initGraphs();
-  initChat();
+  if (!archive) initChat();
   initFocus();
   initFlip();
   initSounds();
@@ -100,11 +104,12 @@ function init() {
   // Setup window resize handler
   $(window).on('resize', handleWindowResize);
 
-  // Socket event handlers
-  setupSocketEvents();
-
-  // Connect!
-  socket.connect();
+  // Live mode only: wire and open the socket. Archive mode is populated from disk
+  // by the games component (auto-loads the latest game on init).
+  if (!archive) {
+    setupSocketEvents();
+    socket.connect();
+  }
 }
 
 // Start when DOM is ready

--- a/public/js/utils/url.ts
+++ b/public/js/utils/url.ts
@@ -1,3 +1,18 @@
 export function getPort(): number {
   return +window.location.pathname.replace(/\//g, '');
 }
+
+// Archive (previous broadcast) pages live at `/archive/<slug>`. Detecting the mode
+// and the API base from the pathname keeps the data layer self-contained — no
+// server-injected globals needed.
+export function isArchive(): boolean {
+  return window.location.pathname.startsWith('/archive/');
+}
+
+export function archiveSlug(): string {
+  return decodeURIComponent(window.location.pathname.split('/')[2] ?? '');
+}
+
+export function apiBase(): string {
+  return isArchive() ? `/archive/${archiveSlug()}` : `/${getPort()}`;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -143,3 +143,10 @@ export type StoredTournamentResults = {
   parsedResults: ParsedResults | null;
   parsedGames: GameRecord[];
 };
+
+export type ArchiveSummary = {
+  slug: string;
+  site: string;
+  updated: string; // ISO 8601 timestamp
+  gameCount: number;
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,14 +3,38 @@ import broadcasts, { Broadcast } from '../broadcast.js';
 import { siteSlug } from '../util/index.js';
 import { getFiles } from '../services/pgn-cache.js';
 import { getMetaFile, getMetaFileUrl } from '../services/game-meta.js';
+import { listArchivedTournaments, loadTournamentResults } from '../services/tournament-results.js';
+import type { GameRecord, StoredTournamentResults } from '../../shared/types.js';
 
 interface RequestWithBroadcast extends Request {
   broadcast: Broadcast;
 }
 
+interface RequestWithArchive extends Request {
+  archive: StoredTournamentResults;
+  archiveSlug: string;
+}
+
 const router = Router();
 
-router.get('/', (_: Request, res: Response): void => {
+// Enriches stored game records with on-disk PGN/meta URLs. Shared by the live
+// (`/:port/games/json`) and archive (`/archive/:slug/games/json`) routes.
+async function enrichGames(slug: string, parsedGames: GameRecord[]): Promise<GameRecord[]> {
+  const pgnFiles = await getFiles(slug);
+  return Promise.all(
+    parsedGames.map(async (g) => {
+      const filename = pgnFiles.get(g.gameNumber);
+      const metaUrl = await getMetaFileUrl(slug, g.gameNumber);
+      return {
+        ...g,
+        pgnUrl: filename ? `/pgns/${slug}/${filename}` : undefined,
+        metaUrl,
+      };
+    }),
+  );
+}
+
+router.get('/', async (_: Request, res: Response): Promise<void> => {
   const broadcastList = Array.from(broadcasts.values())
     .map((b) => {
       const kibitzerData = b.kibitzerManager?.getLiveData(b.port) ?? null;
@@ -31,7 +55,11 @@ router.get('/', (_: Request, res: Response): void => {
     })
     .sort((a, b) => b.viewerCount - a.viewerCount);
 
-  res.render('pages/broadcasts', { broadcasts: broadcastList });
+  // Exclude tournaments that are currently live — they already appear above.
+  const liveSlugs = new Set(Array.from(broadcasts.values()).map((b) => siteSlug(b.game.site)));
+  const archived = (await listArchivedTournaments()).filter((t) => !liveSlugs.has(t.slug));
+
+  res.render('pages/broadcasts', { broadcasts: broadcastList, archived });
 });
 
 router.get('/broadcasts', (_: Request, res: Response): void => {
@@ -55,7 +83,13 @@ router.use('/:port([0-9]+)', (req: Request, res: Response, next: NextFunction): 
 
 router.get('/:port([0-9]+)', (req: Request, res: Response): void => {
   const { broadcast } = req as RequestWithBroadcast;
-  res.render('pages/index', { game: broadcast.game, port: broadcast.port });
+  res.render('pages/index', {
+    game: broadcast.game,
+    port: broadcast.port,
+    archive: false,
+    slug: null,
+    site: broadcast.game.site,
+  });
 });
 
 router.get('/:port([0-9]+)/pgn', (req: Request, res: Response): void => {
@@ -92,18 +126,7 @@ router.get('/:port([0-9]+)/games/json', async (req: Request, res: Response): Pro
   }
 
   const slug = siteSlug(broadcast.game.site);
-  const pgnFiles = await getFiles(slug);
-  const games = await Promise.all(
-    broadcast.parsedGames.map(async (g) => {
-      const filename = pgnFiles.get(g.gameNumber);
-      const metaUrl = await getMetaFileUrl(slug, g.gameNumber);
-      return {
-        ...g,
-        pgnUrl: filename ? `/pgns/${slug}/${filename}` : undefined,
-        metaUrl,
-      };
-    }),
-  );
+  const games = await enrichGames(slug, broadcast.parsedGames);
 
   res.status(200).json(games);
 });
@@ -120,6 +143,66 @@ router.get('/:port([0-9]+)/games/:gameNumber([0-9]+)/meta', async (req: Request,
   }
 
   res.status(200).json(meta);
+});
+
+// --- Archive (previous broadcasts) ---
+// Slugs are produced by `siteSlug` (slugify with `_`), so a safe slug is lowercase
+// alphanumerics + underscores. Reject anything else to keep the value out of the
+// `pgns/{slug}/...` path (defense against traversal).
+const SAFE_SLUG = /^[a-z0-9_]+$/i;
+
+router.use('/archive/:slug', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  const { slug } = req.params;
+
+  if (!SAFE_SLUG.test(slug)) {
+    res.redirect('/');
+    return;
+  }
+
+  const archive = await loadTournamentResults(slug);
+  if (!archive) {
+    res.redirect('/');
+    return;
+  }
+
+  (req as RequestWithArchive).archive = archive;
+  (req as RequestWithArchive).archiveSlug = slug;
+  next();
+});
+
+router.get('/archive/:slug', (req: Request, res: Response): void => {
+  const { archive, archiveSlug } = req as RequestWithArchive;
+  res.render('pages/index', { archive: true, slug: archiveSlug, site: archive.site, port: null, game: null });
+});
+
+router.get('/archive/:slug/games/json', async (req: Request, res: Response): Promise<void> => {
+  const { archive, archiveSlug } = req as RequestWithArchive;
+  const games = await enrichGames(archiveSlug, archive.parsedGames);
+  res.status(200).json(games);
+});
+
+router.get('/archive/:slug/games/:gameNumber([0-9]+)/meta', async (req: Request, res: Response): Promise<void> => {
+  const { archiveSlug } = req as RequestWithArchive;
+  const gameNumber = parseInt(req.params.gameNumber, 10);
+  const meta = await getMetaFile(archiveSlug, gameNumber);
+
+  if (!meta) {
+    res.status(404).json({ error: 'No metadata available for this game' });
+    return;
+  }
+
+  res.status(200).json(meta);
+});
+
+router.get('/archive/:slug/result-table/json', (req: Request, res: Response): void => {
+  const { archive } = req as RequestWithArchive;
+
+  if (!archive.parsedResults) {
+    res.status(404).json({ error: 'No results available' });
+    return;
+  }
+
+  res.status(200).json(archive.parsedResults);
 });
 
 export default router;

--- a/src/services/tournament-results.ts
+++ b/src/services/tournament-results.ts
@@ -1,7 +1,8 @@
 import fs from 'fs/promises';
+import type { Dirent } from 'fs';
 import { mkdirp } from 'mkdirp';
 import type { Broadcast } from '../broadcast.js';
-import type { StoredTournamentResults } from '../../shared/types.js';
+import type { ArchiveSummary, StoredTournamentResults } from '../../shared/types.js';
 import { logger, siteSlug as toSiteSlug } from '../util/index.js';
 
 const RESULTS_FILENAME = 'tournament-results.json';
@@ -30,4 +31,40 @@ export async function saveTournamentResults(broadcast: Broadcast): Promise<void>
   } catch (error) {
     logger.error(`Unable to write tournament results! - ${error}`, { port: broadcast.port });
   }
+}
+
+export async function loadTournamentResults(slug: string): Promise<StoredTournamentResults | null> {
+  try {
+    const raw = await fs.readFile(`pgns/${slug}/${RESULTS_FILENAME}`, 'utf-8');
+    return JSON.parse(raw) as StoredTournamentResults;
+  } catch {
+    return null;
+  }
+}
+
+export async function listArchivedTournaments(): Promise<ArchiveSummary[]> {
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir('pgns', { withFileTypes: true });
+  } catch {
+    logger.info('No pgns directory found, skipping archive listing');
+    return [];
+  }
+
+  const summaries: ArchiveSummary[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const stored = await loadTournamentResults(entry.name);
+    if (!stored) continue;
+
+    summaries.push({
+      slug: entry.name,
+      site: stored.site,
+      updated: stored.updated,
+      gameCount: stored.parsedGames.length,
+    });
+  }
+
+  return summaries.sort((a, b) => b.updated.localeCompare(a.updated));
 }

--- a/views/pages/broadcasts.ejs
+++ b/views/pages/broadcasts.ejs
@@ -126,6 +126,30 @@
         <% }); %>
       </div>
       <% } %>
+
+      <% if (archived && archived.length) { %>
+      <%
+        function formatArchiveDate(iso) {
+          var d = new Date(iso);
+          if (isNaN(d.getTime())) return '';
+          return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+        }
+      %>
+      <div class="page-header">
+        <h2>Previous Broadcasts</h2>
+      </div>
+      <div class="archive-grid">
+        <% archived.forEach(function(t) { %>
+        <a href="/archive/<%= t.slug %>" class="archive-card">
+          <div class="archive-title"><%= t.site %></div>
+          <div class="archive-meta">
+            <span class="archive-games"><%= t.gameCount %> game<%= t.gameCount === 1 ? '' : 's' %></span>
+            <span class="archive-date"><%= formatArchiveDate(t.updated) %></span>
+          </div>
+        </a>
+        <% }); %>
+      </div>
+      <% } %>
     </div>
     <%- include('../partials/footer') %>
   </body>

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <title><%= game.white.name %> vs <%= game.black.name %> (<%= game.site %>)</title>
+    <title><% if (archive) { %><%= site %> — Archive<% } else { %><%= game.white.name %> vs <%= game.black.name %> (<%= game.site %>)<% } %></title>
     <%- include('../partials/analytics') %>
   </head>
   <body>
-    <%- include('../partials/header', { siteName: game.site, showFocus: true, showFlip: true }) %>
+    <%- include('../partials/header', { siteName: archive ? site : game.site, showFocus: true, showFlip: true }) %>
     <div class="container">
       <div class="main-layout">
         <div id="board-container">
@@ -27,7 +27,7 @@
         <div id="resize-handle" title="Resize Board"><span></span></div>
         <div class="right-column">
           <%- include('../partials/info-card', { color: 'black' }) %>
-          <%- include('../partials/chat') %>
+          <%- include('../partials/chat', { archive, port }) %>
           <%- include('../partials/info-card', { color: 'white' }) %>
         </div>
       </div>

--- a/views/partials/chat.ejs
+++ b/views/partials/chat.ejs
@@ -1,13 +1,16 @@
-<div id="chat-area" data-active-tab="chat">
+<div id="chat-area" data-active-tab="<%= archive ? 'games' : 'chat' %>">
   <div id="tab-bar">
+    <% if (!archive) { %>
     <button class="tab-btn active" data-tab="chat">Chat</button>
+    <% } %>
     <button class="tab-btn" data-tab="moves">Moves</button>
     <button class="tab-btn" data-tab="graphs">Graphs</button>
     <button class="tab-btn" data-tab="results">Results</button>
-    <button class="tab-btn" data-tab="games">Games</button>
+    <button class="tab-btn<%= archive ? ' active' : '' %>" data-tab="games">Games</button>
     <button class="tab-btn" data-tab="details">Details</button>
   </div>
 
+  <% if (!archive) { %>
   <div id="chat-tab-panel" class="tab-panel">
     <div class="card fluid" id="chat-box"></div>
     <input placeholder="Anonymous" id="username" />
@@ -15,6 +18,7 @@
     <input placeholder="Type your message here..." id="chat-msg" />
     <button class="primary" id="chat-btn">Send</button>
   </div>
+  <% } %>
 
   <div id="moves-tab-panel" class="tab-panel">
     <div class="card fluid" id="moves-card">
@@ -24,9 +28,11 @@
           <button id="copy-fen-btn" title="Copy FEN">
             <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
           </button>
+          <% if (!archive) { %>
           <a href="/<%= port %>/pgn" target="_blank" id="pgn-btn" title="Download PGN">
             <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
           </a>
+          <% } %>
         </div>
       </div>
       <div id="move-list"></div>
@@ -63,10 +69,12 @@
         <span class="details-link-label">PGN Archive</span>
         <svg class="details-link-arrow" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
       </a>
+      <% if (!archive) { %>
       <a href="/<%= port %>/pgn" target="_blank" class="details-link">
         <span class="details-link-label">Current Game PGN</span>
         <svg class="details-link-arrow" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
       </a>
+      <% } %>
       <a id="schedule" href="#" target="_blank" class="details-link" hidden>
         <span class="details-link-label">Schedule</span>
         <svg class="details-link-arrow" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>


### PR DESCRIPTION
## Summary

Surfaces the persisted tournament results and per-game meta/PGN sidecars (from #161) as a read-only **archive**. The homepage now lists **Previous Broadcasts** (tournaments that aren't currently live); clicking one opens the normal broadcast page in **archive mode**, populated from the saved `pgns/{slug}/` directory, where users can browse the games list, view standings, and replay any game. The **Chat tab is removed** in this mode since there's no live feed.

## Why

`tournament-results.json` plus the `.meta.json`/`.pgn` sidecars were being written to disk but had no frontend wiring — this makes them browsable.

## Backend
- `loadTournamentResults(slug)` / `listArchivedTournaments()` read helpers in `src/services/tournament-results.ts`.
- Slug-validated `/archive/:slug` routes (page render + `games/json`, `games/:n/meta`, `result-table/json`) mirroring the live `/:port` routes, via a shared `enrichGames()` helper.
- Homepage `GET /` excludes tournaments that are currently live (by slug) to avoid duplicating the live grid.

## Frontend
- Pathname-derived `apiBase()` / `isArchive()` / `archiveSlug()` so the data layer needs no server-injected globals.
- Archive mode skips the Socket.IO connection + chat init, auto-loads the most recent game onto the board, and defaults to the Games tab.
- The replay "Back to Live" banner is **not** rendered in archive mode (no live game to return to — game switching happens via the Games list).
- EJS templates drop the Chat tab and live-only PGN links when archived; archive cards on the homepage show site name, last-updated date, and game count (newest first).

## Decisions
- Previous Broadcasts excludes currently-live tournaments.
- Archive pages auto-load the most recent game.
- Archive cards show site + date + game count.

## Verification
- `npm run prebuild` (full frontend type-check via ts-loader) passes; ESLint clean; backend `tsc` shows only the pre-existing `@types/ssh2` conflict.
- Exercised the disk-read service chain (`listArchivedTournaments` / `loadTournamentResults` / `getFiles` / `getMetaFile`) against synthetic archive data.
- End-to-end in a real browser (server + public on :8081, isolated empty-connections config, synthetic two-game archive): homepage archive card, archive page with no Chat tab, auto-loaded latest game, move-list navigation (board FEN matches), Results standings, replaying a different game, and malformed/nonexistent slugs → `302 /`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)