### PR TITLE
feat: support archived broadcasts without tournament-results.json

### DIFF
--- a/src/game-service.ts
+++ b/src/game-service.ts
@@ -7,7 +7,7 @@ import { fetchOpening, fetchTablebase } from './services/lichess.js';
 import type { OpeningResult } from './services/lichess.js';
 import { savePgn } from './services/pgn.js';
 import { saveGameMeta, invalidate as invalidateMetaCache } from './services/game-meta.js';
-import { saveTournamentResults } from './services/tournament-results.js';
+import { saveTournamentResults, invalidateArchiveCache } from './services/tournament-results.js';
 import { invalidate as invalidatePgnCache } from './services/pgn-cache.js';
 import { Command, splitOnCommand } from './protocol.js';
 import { EmitType } from './socket-io-adapter.js';
@@ -357,6 +357,7 @@ class GameService {
       const oldSlug = siteSlug(this.game.site);
       invalidatePgnCache(oldSlug);
       invalidateMetaCache(oldSlug);
+      invalidateArchiveCache(oldSlug);
     }
     this.game.site = site.replace('GrahamCCRL.dyndns.org\\', '').replace(/\.[\w]+$/, '');
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,7 +3,7 @@ import broadcasts, { Broadcast } from '../broadcast.js';
 import { siteSlug } from '../util/index.js';
 import { getFiles } from '../services/pgn-cache.js';
 import { getMetaFile, getMetaFileUrl } from '../services/game-meta.js';
-import { listArchivedTournaments, loadTournamentResults } from '../services/tournament-results.js';
+import { listArchivedTournaments, loadOrReconstructArchive } from '../services/tournament-results.js';
 import type { GameRecord, StoredTournamentResults } from '../../shared/types.js';
 
 interface RequestWithBroadcast extends Request {
@@ -159,7 +159,7 @@ router.use('/archive/:slug', async (req: Request, res: Response, next: NextFunct
     return;
   }
 
-  const archive = await loadTournamentResults(slug);
+  const archive = await loadOrReconstructArchive(slug);
   if (!archive) {
     res.redirect('/');
     return;

--- a/src/services/game-meta.ts
+++ b/src/services/game-meta.ts
@@ -9,6 +9,7 @@ const metaCache = new FileCache(/^(\d+)_.+\.meta\.json$/i);
 
 export const loadAll = metaCache.loadAll.bind(metaCache);
 export const invalidate = metaCache.invalidate.bind(metaCache);
+export const getMetaFiles = metaCache.getFiles.bind(metaCache);
 
 export async function getMetaFile(siteSlug: string, gameNumber: number): Promise<StoredGameMeta | null> {
   const files = await metaCache.getFiles(siteSlug);

--- a/src/services/tournament-results.ts
+++ b/src/services/tournament-results.ts
@@ -2,10 +2,20 @@ import fs from 'fs/promises';
 import type { Dirent } from 'fs';
 import { mkdirp } from 'mkdirp';
 import type { Broadcast } from '../broadcast.js';
-import type { ArchiveSummary, StoredTournamentResults } from '../../shared/types.js';
+import type { ArchiveSummary, GameRecord, StoredTournamentResults } from '../../shared/types.js';
 import { logger, siteSlug as toSiteSlug } from '../util/index.js';
+import { getMetaFile, getMetaFiles } from './game-meta.js';
 
 const RESULTS_FILENAME = 'tournament-results.json';
+
+// Reconstructed archives (built from meta sidecars when no results.json exists) are
+// cached per slug: the `/archive/:slug` middleware runs on every sub-request, and a
+// large gauntlet would otherwise re-read every meta file several times per page load.
+const archiveCache = new Map<string, StoredTournamentResults>();
+
+export function invalidateArchiveCache(slug: string): void {
+  archiveCache.delete(slug);
+}
 
 export async function saveTournamentResults(broadcast: Broadcast): Promise<void> {
   // Fire-and-forget from the message loop, so the whole body is guarded — a throw
@@ -42,6 +52,57 @@ export async function loadTournamentResults(slug: string): Promise<StoredTournam
   }
 }
 
+// Synthesizes a StoredTournamentResults from the per-game meta sidecars for
+// tournaments that predate the results.json roll-up (PR #161). Standings are left
+// null (the result table renders "no information"); the games schedule is rebuilt
+// from each meta's player names + result. Returns null when no meta sidecars exist
+// (e.g. truly-legacy PGN-only folders — we intentionally do not parse PGNs).
+export async function reconstructArchiveFromMeta(slug: string): Promise<StoredTournamentResults | null> {
+  const cached = archiveCache.get(slug);
+  if (cached) return cached;
+
+  const metaFiles = await getMetaFiles(slug);
+  if (metaFiles.size === 0) return null;
+
+  let site: string | null = null;
+  const parsedGames: GameRecord[] = [];
+  for (const gameNumber of metaFiles.keys()) {
+    const meta = await getMetaFile(slug, gameNumber);
+    if (!meta) continue;
+    if (!site) site = meta.site;
+    parsedGames.push({ gameNumber, white: meta.white.name, black: meta.black.name, result: meta.result });
+  }
+
+  if (parsedGames.length === 0) return null;
+  parsedGames.sort((a, b) => a.gameNumber - b.gameNumber);
+
+  const archive: StoredTournamentResults = {
+    site: site ?? slug,
+    port: 0,
+    updated: await dirUpdatedAt(slug),
+    results: '',
+    parsedResults: null,
+    parsedGames,
+  };
+
+  archiveCache.set(slug, archive);
+  return archive;
+}
+
+// Returns a results.json-backed archive when present, otherwise a meta-reconstructed
+// one. Used by the archive routes so older tournaments are openable.
+export async function loadOrReconstructArchive(slug: string): Promise<StoredTournamentResults | null> {
+  return (await loadTournamentResults(slug)) ?? (await reconstructArchiveFromMeta(slug));
+}
+
+async function dirUpdatedAt(slug: string): Promise<string> {
+  try {
+    return (await fs.stat(`pgns/${slug}`)).mtime.toISOString();
+  } catch {
+    return new Date(0).toISOString();
+  }
+}
+
 export async function listArchivedTournaments(): Promise<ArchiveSummary[]> {
   let entries: Dirent[];
   try {
@@ -56,13 +117,29 @@ export async function listArchivedTournaments(): Promise<ArchiveSummary[]> {
     if (!entry.isDirectory()) continue;
 
     const stored = await loadTournamentResults(entry.name);
-    if (!stored) continue;
+    if (stored) {
+      summaries.push({
+        slug: entry.name,
+        site: stored.site,
+        updated: stored.updated,
+        gameCount: stored.parsedGames.length,
+      });
+      continue;
+    }
+
+    // Fallback for tournaments that predate the results.json roll-up but still have
+    // per-game meta sidecars. Build a light summary without reading every meta.
+    const metaFiles = await getMetaFiles(entry.name);
+    if (metaFiles.size === 0) continue;
+
+    const firstKey = metaFiles.keys().next().value as number;
+    const firstMeta = await getMetaFile(entry.name, firstKey);
 
     summaries.push({
       slug: entry.name,
-      site: stored.site,
-      updated: stored.updated,
-      gameCount: stored.parsedGames.length,
+      site: firstMeta?.site ?? entry.name,
+      updated: await dirUpdatedAt(entry.name),
+      gameCount: metaFiles.size,
     });
   }
 


### PR DESCRIPTION
## Problem

The **Previous Broadcasts** archive (#165) is gated entirely on the `tournament-results.json` roll-up added in #161:

- `listArchivedTournaments()` skips any folder where `loadTournamentResults()` is null → the tournament never appears on the homepage.
- The `/archive/:slug` middleware redirects to `/` when `loadTournamentResults()` is null → the page can't be opened directly.

So any tournament that finished before #161 shipped is invisible and unopenable — **including folders that already have per-game `.meta.json` replay sidecars** (added earlier, in the replay feature). On a typical install that's tournaments like `PZChessBot_4CPU_Gauntlet` and `Raphael_4CPU_Gauntlet`.

## Approach

Reconstruct an equivalent `StoredTournamentResults` from the meta sidecars **on the fly** when the roll-up is absent — no disk writes, no migration.

- `reconstructArchiveFromMeta(slug)` builds the games list from each meta's player names + result, with `parsedResults: null` (the result table renders **"No results available."**). Cached per slug since the archive middleware runs on every sub-request; the cache is invalidated alongside the existing meta/pgn caches on a slug change.
- `loadOrReconstructArchive(slug)` prefers the roll-up, else reconstructs.
- `listArchivedTournaments()` lists meta-only folders via a light summary (one meta read for the site name, file count, dir mtime).
- The archive middleware uses `loadOrReconstructArchive`; **downstream routes, `enrichGames`, the meta route, and the frontend are unchanged** (the games tab already hides the replay button when no `metaUrl`, and the results tab already renders "No results available." on a 404).

## Scope boundary

Replay works wherever a meta sidecar exists. Truly-legacy folders that have only `.pgn` files and no meta sidecars **intentionally stay hidden** — per decision, we do not parse PGNs.

## Verification

- `tsc` (with `--skipLibCheck` to bypass an unrelated, pre-existing `@types/ssh2` toolchain issue in the dev env): zero `src/`/`shared/` errors. ESLint + Prettier clean.
- Ran the compiled server against real archive data and drove it with a browser:
  - Homepage **Previous Broadcasts** lists the previously-hidden meta-only tournaments; PGN-only folders stay hidden.
  - `/archive/<slug>` opens (no redirect); **Games** tab lists the game with working **View**/replay + PGN download; **Results** tab shows "No results available."; replaying renders the move list from the meta sidecar.

> Note: this project has no test runner; verification is via build + manual testing.