### PR TITLE
fix(theme): scale down meridian piece sets to match classic

### DIFF
--- a/public/img/pieces/meridian/bB.svg
+++ b/public/img/pieces/meridian/bB.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian/bK.svg
+++ b/public/img/pieces/meridian/bK.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian/bN.svg
+++ b/public/img/pieces/meridian/bN.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian/bP.svg
+++ b/public/img/pieces/meridian/bP.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian/bQ.svg
+++ b/public/img/pieces/meridian/bQ.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian/bR.svg
+++ b/public/img/pieces/meridian/bR.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian/wB.svg
+++ b/public/img/pieces/meridian/wB.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian/wK.svg
+++ b/public/img/pieces/meridian/wK.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian/wN.svg
+++ b/public/img/pieces/meridian/wN.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian/wP.svg
+++ b/public/img/pieces/meridian/wP.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian/wQ.svg
+++ b/public/img/pieces/meridian/wQ.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian/wR.svg
+++ b/public/img/pieces/meridian/wR.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian_shaded/bB.svg
+++ b/public/img/pieces/meridian_shaded/bB.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian_shaded/bK.svg
+++ b/public/img/pieces/meridian_shaded/bK.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian_shaded/bN.svg
+++ b/public/img/pieces/meridian_shaded/bN.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian_shaded/bP.svg
+++ b/public/img/pieces/meridian_shaded/bP.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian_shaded/bQ.svg
+++ b/public/img/pieces/meridian_shaded/bQ.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian_shaded/bR.svg
+++ b/public/img/pieces/meridian_shaded/bR.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian_shaded/wB.svg
+++ b/public/img/pieces/meridian_shaded/wB.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian_shaded/wK.svg
+++ b/public/img/pieces/meridian_shaded/wK.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian_shaded/wN.svg
+++ b/public/img/pieces/meridian_shaded/wN.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian_shaded/wP.svg
+++ b/public/img/pieces/meridian_shaded/wP.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian_shaded/wQ.svg
+++ b/public/img/pieces/meridian_shaded/wQ.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"

--- a/public/img/pieces/meridian_shaded/wR.svg
+++ b/public/img/pieces/meridian_shaded/wR.svg
@@ -4,6 +4,7 @@
 <svg
    width="64px"
    height="64px"
+   viewBox="-4 -4 72 72"
    id="svg2984"
    version="1.1"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"


### PR DESCRIPTION
## Summary

The Meridian and Meridian Shaded piece sets (added in #164) rendered noticeably larger than Classic within each board square. Their glyphs fill ~90% of the 64-unit SVG canvas, vs ~75% for Classic.

This scales both Meridian sets down to match Classic by adding a symmetric padded `viewBox="-4 -4 72 72"` to all 24 SVGs — mapping a 72-unit window into the same canvas, shrinking the glyph to `64/72 ≈ 0.89` and re-centering it in place.

## Why viewBox

`viewBox` changes only the coordinate mapping, not any path coordinates or gradient definitions, so Meridian Shaded's `userSpaceOnUse` gradient stays aligned. It fixes every render path at once (main board, mini boards, replay, broadcasts, pre-JS fallback) with **zero** TypeScript/SCSS changes.

## Measured fit (rendered glyph height ÷ square)

| Piece | Classic | Meridian before | Meridian after |
|---|---|---|---|
| King | 0.747 | 0.835 | **0.742** |
| Pawn | 0.678 | 0.750 | **0.667** |

## Verification

- `npm run prebuild` (webpack) compiles cleanly.
- Verified live on broadcast 16061: switched the Theme → Pieces dropdown between Classic / Meridian / Meridian Shaded. Meridian pieces now sit at the Classic scale with proper margins; Meridian Shaded keeps its gradient shading.

Files: only the 24 `public/img/pieces/meridian/*.svg` and `public/img/pieces/meridian_shaded/*.svg` assets, one `viewBox` attribute each.