### PR TITLE
feat: add opt-in ephemeral local UDP port per connection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ Socket.IO events:
 Configuration is in `config/config.json`:
 ```json
 {
-  "connections": ["hostname:port", "hostname:port", ...],
+  "connections": ["hostname:port", { "connection": "hostname:port", "ephemeral": true }, ...],
   "kibitzers": [
     { "id": "a1b2c3d4", "type": "local", "priority": 10, "enginePath": "/usr/bin/stockfish", "threads": 4, "hash": 512 },
     { "id": "e5f6g7h8", "type": "ssh", "priority": 5, "host": "example.com", "username": "user", "privateKeyPath": "/path/to/key", "enginePath": "/usr/bin/stockfish", "threads": 8, "hash": 2048 }
@@ -224,6 +224,8 @@ Configuration is in `config/config.json`:
   ]
 }
 ```
+
+Each `connections` entry is either a bare `"host:port"` string (default mode) or an object `{ "connection": "host:port", "ephemeral": true }`. The optional `ephemeral` flag binds an OS-assigned local UDP port instead of the broadcast port (see the UDP bind gotcha below). Both forms are accepted on read; the admin "Add new" form writes a bare string unless the "Ephemeral local port" checkbox is set.
 
 The `kibitzers` array is optional. Each entry has an `id` (auto-assigned at startup if missing), a `type` (`"local"` or `"ssh"`), a `priority` (higher = assigned to more-viewed broadcasts), and type-specific fields. SSH entries also require `host`, `username`, `privateKeyPath`, and `enginePath`. Both types accept optional `port` (SSH only, default 22), `threads` (default 1), and `hash` (default 256).
 
@@ -290,5 +292,6 @@ Environment variables (see `.env.example`; `.env` is gitignored and loaded via `
 - **Webhook game-started dedup**: `GameService` fires one game-started event per game via a re-arm state machine (`gameStartArmed` / `startColorsSeen`). It is re-armed in `onResult()`. Connecting mid-game fires one game-started for the already-in-progress game — accepted.
 - **Webhook URL is a secret**: Discord webhook URLs embed a token. The admin table masks all but the last 8 chars, but the edit button still carries the full URL in a `data-url` attribute (admin page is basic-auth protected).
 - **No-op protocol commands**: `LOGON` (the `LOGON SUCCESSFUL` handshake reply), `FEATURE`, and `level` are recognized in the `Command` enum with no-op handlers (`() => [EmitType.UPDATE, false]`, same pattern as `PONG`). They are connection-time handshake/config lines the viewer derives nothing from (clocks come from `WTIME`/`BTIME`, not `level`); the handlers exist purely to suppress the `Unable to process <cmd>!` warning in `categorizeMessages`.
-- **UDP local bind = broadcast port is mandatory**: `UdpTransport` binds the local socket to the broadcast port (`udp-transport.ts`). This is required, not a convention: the TLCS server streams the broadcast to `clientIP:<broadcast port>` and ignores the source port of our `LOGONv15` (verified empirically — a LOGON sent from a different source port still has its data delivered to the broadcast port). Consequences: you cannot bind an ephemeral local port and still receive data, and two instances on the same host cannot watch the *same* broadcast (both need that port → `EADDRINUSE`). To run multiple worktrees, point each `config/config.json` at a **different** broadcast port.
+- **UDP local bind = broadcast port (default mode)**: by default `UdpTransport` binds the local socket to the broadcast port (`udp-transport.ts`). This is required for classic TLCS, not a convention: the server streams the broadcast to `clientIP:<broadcast port>` and ignores the source port of our `LOGONv15` (verified empirically — a LOGON sent from a different source port still has its data delivered to the broadcast port). Consequences in default mode: you cannot bind an ephemeral local port and still receive data, and two instances on the same host cannot watch the *same* broadcast (both need that port → `EADDRINUSE`). To run multiple worktrees against classic TLCS, point each `config/config.json` at a **different** broadcast port.
+- **Ephemeral mode (opt-in per connection)**: the optional `ephemeral` flag on a `connections` entry calls `socket.bind()` (OS-assigned local port) instead of `socket.bind(<broadcast port>)`. The remote send destination is unchanged (still `host:<broadcast port>`) — only our *source* port differs. This only works against a server that replies to our source port (e.g. the sibling `uci-to-tlcs` broadcaster); classic TLCS (Graham's) still replies to the broadcast port, so ephemeral mode would receive nothing there. Because the broadcast port is not bound, multiple instances on one host **can** watch the same ephemeral broadcast. The broadcast port remains the identity everywhere (Map key, `/:port` route, Socket.IO room, metrics) regardless of mode; the flag is threaded `UdpTransport` ← `Connection` ← `Broadcast` and preserved across `reconnect()`.
 - **No test infrastructure**: This project has no test runner or test files. Verification is done via `npm run build` (TypeScript + webpack) and manual testing.

--- a/public/js/admin.ts
+++ b/public/js/admin.ts
@@ -15,11 +15,11 @@ function closeBroadcast(connection: string) {
   });
 }
 
-function addNewBroadcast(connection: string) {
+function addNewBroadcast(connection: string, ephemeral: boolean) {
   $.ajax({
     type: 'POST',
     url: '/admin/new',
-    data: JSON.stringify({ connection }),
+    data: JSON.stringify({ connection, ephemeral }),
     contentType: 'application/json',
     complete() {
       window.location.reload();
@@ -162,7 +162,8 @@ $(document).ready(() => {
     e.preventDefault();
     const connection = $('#connection').val() as string;
     if (!connection) return;
-    addNewBroadcast(connection);
+    const ephemeral = $('#ephemeral').prop('checked') as boolean;
+    addNewBroadcast(connection, ephemeral);
   });
 
   $('button.close').click(function handleClose() {

--- a/src/broadcast-manager.ts
+++ b/src/broadcast-manager.ts
@@ -30,22 +30,22 @@ export function getWebhookManager(): WebhookManager | null {
 export async function connect(): Promise<void> {
   const connections = await configStore.getConnections();
 
-  for (const c of connections) {
-    const [url, port] = c.split(':');
+  for (const { connection, ephemeral } of connections) {
+    const [url, port] = connection.split(':');
     const ip = await lookup(url);
 
-    broadcasts.set(+port, new Broadcast(url, ip, +port, _kibitzerManager ?? undefined));
+    broadcasts.set(+port, new Broadcast(url, ip, +port, _kibitzerManager ?? undefined, ephemeral));
   }
 }
 
-export async function newConnection(connection: string): Promise<void> {
+export async function newConnection(connection: string, ephemeral = false): Promise<void> {
   const [url, port] = connection.split(':');
   const ip = await lookup(url);
 
   if (broadcasts.has(+port)) throw Error('Port already in use!');
 
-  broadcasts.set(+port, new Broadcast(url, ip, +port, _kibitzerManager ?? undefined));
-  await configStore.addConnection(connection);
+  broadcasts.set(+port, new Broadcast(url, ip, +port, _kibitzerManager ?? undefined, ephemeral));
+  await configStore.addConnection(connection, ephemeral);
 }
 
 export async function closeConnection(connection: string): Promise<void> {

--- a/src/broadcast.ts
+++ b/src/broadcast.ts
@@ -16,6 +16,7 @@ export class Broadcast {
   readonly host: string;
   readonly ip: string;
   readonly port: number;
+  readonly ephemeral: boolean;
   readonly game: ChessGame;
   readonly kibitzerManager: KibitzerManager | null;
   private state: BroadcastState;
@@ -23,16 +24,17 @@ export class Broadcast {
   private conn: Connection;
   private pings!: NodeJS.Timeout;
 
-  constructor(host: string, ip: string, port: number, kibitzerManager?: KibitzerManager) {
+  constructor(host: string, ip: string, port: number, kibitzerManager?: KibitzerManager, ephemeral = false) {
     this.host = host;
     this.ip = ip;
     this.port = port;
+    this.ephemeral = ephemeral;
 
     this.kibitzerManager = kibitzerManager ?? null;
     this.state = new BroadcastState();
     this.game = new ChessGame(String(this.port));
     this.gameService = new GameService(this);
-    this.conn = new Connection(this.ip, this.port, this.processMessages.bind(this));
+    this.conn = new Connection(this.ip, this.port, this.processMessages.bind(this), this.ephemeral);
 
     this.connect();
     this.reloadResults();
@@ -64,7 +66,7 @@ export class Broadcast {
     this.conn.close();
 
     setTimeout(() => {
-      this.conn = new Connection(this.ip, this.port, this.processMessages.bind(this));
+      this.conn = new Connection(this.ip, this.port, this.processMessages.bind(this), this.ephemeral);
       this.connect();
     }, 500);
   }

--- a/src/config/config-store.ts
+++ b/src/config/config-store.ts
@@ -3,10 +3,22 @@ import path from 'node:path';
 import type { KibitzerConfig } from '../kibitzer/types.js';
 import type { WebhookConfig } from '../webhooks/types.js';
 
+export interface ConnectionConfig {
+  connection: string;
+  ephemeral?: boolean;
+}
+
+/** A connections entry is either a bare "host:port" string or a config object. */
+export type ConnectionEntry = string | ConnectionConfig;
+
 export interface AppConfig {
-  connections: string[];
+  connections: ConnectionEntry[];
   kibitzers?: KibitzerConfig[];
   webhooks?: WebhookConfig[];
+}
+
+function normalizeConnection(entry: ConnectionEntry): ConnectionConfig {
+  return typeof entry === 'string' ? { connection: entry, ephemeral: false } : { ephemeral: false, ...entry };
 }
 
 export class ConfigStore {
@@ -26,20 +38,24 @@ export class ConfigStore {
     await fs.writeFile(this.configPath, JSON.stringify(config, null, 2), { encoding: 'utf8' });
   }
 
-  async getConnections(): Promise<string[]> {
+  async getConnections(): Promise<ConnectionConfig[]> {
     const config = await this.load();
-    return config.connections;
+    return config.connections.map(normalizeConnection);
   }
 
-  async addConnection(connection: string): Promise<void> {
+  async addConnection(connection: string, ephemeral = false): Promise<void> {
     const config = await this.load();
-    config.connections = [...new Set([...config.connections, connection])];
+    const existing = config.connections.filter((c) => normalizeConnection(c).connection !== connection);
+    // Keep the file tidy: a bare string for the default mode, an object only when
+    // ephemeral is set. Reads tolerate both forms via normalizeConnection().
+    const entry: ConnectionEntry = ephemeral ? { connection, ephemeral: true } : connection;
+    config.connections = [...existing, entry];
     await this.save(config);
   }
 
   async removeConnection(connection: string): Promise<void> {
     const config = await this.load();
-    config.connections = config.connections.filter((c) => c !== connection);
+    config.connections = config.connections.filter((c) => normalizeConnection(c).connection !== connection);
     await this.save(config);
   }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -6,9 +6,9 @@ class Connection {
 
   private messageBuffer: MessageBuffer;
 
-  constructor(host: string, port: number, onBatch: BatchConsumer) {
+  constructor(host: string, port: number, onBatch: BatchConsumer, ephemeral = false) {
     this.messageBuffer = new MessageBuffer(port, onBatch);
-    this.transport = new UdpTransport(host, port, (msg) => this.messageBuffer.push(msg));
+    this.transport = new UdpTransport(host, port, (msg) => this.messageBuffer.push(msg), ephemeral);
   }
 
   send(msg: string): void {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -42,10 +42,11 @@ router.post('/close', async (req: Request, res: Response) => {
 
 router.post('/new', async (req: Request, res: Response) => {
   const { connection } = req.body;
+  const ephemeral = Boolean(req.body.ephemeral);
 
   try {
-    logger.info(`Attempting new connection of ${connection}`);
-    await newConnection(connection);
+    logger.info(`Attempting new connection of ${connection}${ephemeral ? ' (ephemeral)' : ''}`);
+    await newConnection(connection, ephemeral);
     res.sendStatus(200);
   } catch (error) {
     logger.warn(`Unable to add connection ${connection}`);

--- a/src/transport/udp-transport.ts
+++ b/src/transport/udp-transport.ts
@@ -12,7 +12,7 @@ export class UdpTransport {
   private onParsedMessage: MessageCallback;
   private closed: boolean;
 
-  constructor(host: string, port: number, onParsedMessage: MessageCallback) {
+  constructor(host: string, port: number, onParsedMessage: MessageCallback, ephemeral = false) {
     this.host = host;
     this.port = port;
     this.onParsedMessage = onParsedMessage;
@@ -24,11 +24,19 @@ export class UdpTransport {
     this.socket.on('listening', this.onListening.bind(this));
     this.socket.on('message', this.onMessage.bind(this));
 
-    // The local socket MUST bind the broadcast port: the TLCS server streams the
-    // broadcast to clientIP:<broadcast port> and ignores the source port of our
-    // LOGON entirely (verified empirically). Binding any other port receives
-    // nothing. This is why two instances on one host cannot share a broadcast.
-    this.socket.bind(port);
+    if (ephemeral) {
+      // Ephemeral mode (opt-in, e.g. for uci-to-tlcs): bind an OS-assigned local
+      // port. The server replies to our source port instead of the broadcast
+      // port, so we can receive without binding the broadcast port. This lets
+      // multiple instances on one host watch the same broadcast (no EADDRINUSE).
+      this.socket.bind();
+    } else {
+      // Classic TLCS: the local socket MUST bind the broadcast port. The server
+      // streams the broadcast to clientIP:<broadcast port> and ignores the source
+      // port of our LOGON entirely (verified empirically). Binding any other port
+      // receives nothing, and two instances on one host cannot share a broadcast.
+      this.socket.bind(port);
+    }
   }
 
   private onError(err: Error): void {
@@ -40,7 +48,9 @@ export class UdpTransport {
 
   private onListening(): void {
     const address = this.socket.address();
-    logger.info(`Listening @ ${address.address}:${address.port}`, { port: this.port });
+    logger.info(`Listening @ ${address.address}:${address.port} (broadcast ${this.host}:${this.port})`, {
+      port: this.port,
+    });
   }
 
   private onMessage(msg: Buffer, rInfo: RemoteInfo): void {

--- a/views/pages/admin.ejs
+++ b/views/pages/admin.ejs
@@ -22,6 +22,7 @@
               <th>Site</th>
               <th>Host</th>
               <th>Port</th>
+              <th>Ephemeral</th>
               <th>Close</th>
             </tr>
           </thead>
@@ -31,6 +32,7 @@
               <td data-label="Site"><%= broadcast.game.site || '—' %></td>
               <td data-label="Host"><%= broadcast.host %></td>
               <td data-label="Port"><%= broadcast.port %></td>
+              <td data-label="Ephemeral"><%= broadcast.ephemeral ? 'Yes' : '—' %></td>
               <td data-label="Close">
                 <button class="secondary close" data-connection="<%= broadcast.connection %>">Close</button>
               </td>
@@ -42,6 +44,11 @@
           <div class="field">
             <label for="connection">Connection</label>
             <input id="connection" name="connection" required placeholder="GrahamCCRL.dyndns.org:16000" />
+          </div>
+          <div class="field">
+            <label class="webhook-event-option">
+              <input type="checkbox" id="ephemeral" name="ephemeral" /> Ephemeral local port
+            </label>
           </div>
           <button type="submit" class="primary">Add new</button>
         </form>


### PR DESCRIPTION
## Summary

Adds an opt-in **per-connection `ephemeral` flag** that binds an OS-assigned local UDP port instead of the broadcast port.

By default `UdpTransport` must bind the broadcast port locally, because classic TLCS (Graham's server) streams the broadcast to `clientIP:<broadcast port>` and ignores our source port. The sibling [`uci-to-tlcs`](https://github.com/jhonnold/uci-to-tlcs) broadcaster instead replies to our **source port**, so when `ephemeral` is set we can bind any OS-assigned local port and still receive — only the source port differs; the remote send destination is unchanged.

This enables two things classic mode can't:
- interoperating with `uci-to-tlcs`, and
- running **multiple instances on one host watching the same broadcast** (no `EADDRINUSE`).

The flag is strictly opt-in; default behavior is unchanged, so Graham's broadcasts keep binding the broadcast port.

## Design

- The broadcast **port stays the identity** everywhere (Map key, `/:port` route, Socket.IO room, metrics, `ChessGame` id). Only the local bind changes — so routes/Socket.IO/metrics needed no changes.
- The flag is threaded `UdpTransport` ← `Connection` ← `Broadcast`, stored on `Broadcast`, and **preserved across `reconnect()`**.
- Config uses a **backward-compatible union**: normal entries stay plain `"host:port"` strings; ephemeral ones are stored as `{ "connection": "host:port", "ephemeral": true }`. `normalizeConnection()` tolerates both on read; writes stay bare strings unless ephemeral is set (no churn to existing configs).
- Admin: "Add new" form gains an **Ephemeral local port** checkbox; the broadcasts table gains an **Ephemeral** column.

## Changes
- `src/transport/udp-transport.ts` — `ephemeral` ctor arg; `socket.bind()` (OS-assigned) vs `socket.bind(port)`; `onListening` logs local + broadcast address.
- `src/connection.ts`, `src/broadcast.ts` — thread the flag through; reuse it in `reconnect()`.
- `src/config/config-store.ts` — union type + `normalizeConnection`; `getConnections()` returns normalized configs; `addConnection(connection, ephemeral)`.
- `src/broadcast-manager.ts` — parse and pass through in `connect()` / `newConnection()`.
- `src/routes/admin.ts`, `views/pages/admin.ejs`, `public/js/admin.ts` — admin UI.
- `CLAUDE.md` — config schema + UDP bind gotcha (default vs ephemeral modes).

## Testing
- `npm run build` (tsc + webpack) and `npm run lint` clean.
- **End-to-end against a live `uci-to-tlcs`:**
  - node-tlcv bound an OS-assigned port (`Listening @ 0.0.0.0:58645 (broadcast 127.0.0.1:16061)`), `uci-to-tlcs` registered the client by that ephemeral port and ACKs round-tripped both ways; `/16061/pgn` showed the received Site/players/FEN.
  - **Two** ephemeral instances on one host watched the same broadcast (ports `58645` and `38772`) with no `EADDRINUSE` — `uci-to-tlcs` reported `2 client(s)`.

Note: the default (non-ephemeral) path against a real Graham server is unchanged and not separately live-tested here.