### PR TITLE
feat: add per-route HTTP request metrics + Grafana panels

### DIFF
--- a/config/grafana-dashboard.json
+++ b/config/grafana-dashboard.json
@@ -1161,6 +1161,445 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 59 },
+      "id": 107,
+      "title": "HTTP — Pages",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 60 },
+      "id": 28,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "title": "Total HTTP req/s",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(ccrl_http_request_duration_seconds_count[5m]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 60 },
+      "id": 29,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "title": "Overall Error %",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "100 * sum(rate(ccrl_http_request_duration_seconds_count{status=~\"5..\"}[5m])) / sum(rate(ccrl_http_request_duration_seconds_count[5m]))",
+          "legendFormat": "5xx %",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "req/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "min": 0,
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 64 },
+      "id": 30,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "sortBy": "Last *", "sortDesc": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Page Volume by Route",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(ccrl_http_request_duration_seconds_count{route=~\"/|/:port|/archive/:slug|/admin\"}[5m])) by (route)",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "latency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "p99" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 64 },
+      "id": 31,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Page Latency (p50 / p90 / p99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum(rate(ccrl_http_request_duration_seconds_bucket{route=~\"/|/:port|/archive/:slug|/admin\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.90, sum(rate(ccrl_http_request_duration_seconds_bucket{route=~\"/|/:port|/archive/:slug|/admin\"}[5m])) by (le))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum(rate(ccrl_http_request_duration_seconds_bucket{route=~\"/|/:port|/archive/:slug|/admin\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "5xx %",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "min": 0,
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 64 },
+      "id": 32,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Page Error Rate (5xx)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "100 * sum(rate(ccrl_http_request_duration_seconds_count{route=~\"/|/:port|/archive/:slug|/admin\", status=~\"5..\"}[5m])) / sum(rate(ccrl_http_request_duration_seconds_count{route=~\"/|/:port|/archive/:slug|/admin\"}[5m]))",
+          "legendFormat": "5xx %",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 72 },
+      "id": 108,
+      "title": "HTTP — API",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "req/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "min": 0,
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 73 },
+      "id": 33,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "sortBy": "Last *", "sortDesc": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "API Volume by Route",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(ccrl_http_request_duration_seconds_count{route=~\"/broadcasts|/:port/.+|/archive/:slug/.+|/admin/.+\"}[5m])) by (route)",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "latency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "p99" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 73 },
+      "id": 34,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "API Latency (p50 / p90 / p99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum(rate(ccrl_http_request_duration_seconds_bucket{route=~\"/broadcasts|/:port/.+|/archive/:slug/.+|/admin/.+\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.90, sum(rate(ccrl_http_request_duration_seconds_bucket{route=~\"/broadcasts|/:port/.+|/archive/:slug/.+|/admin/.+\"}[5m])) by (le))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum(rate(ccrl_http_request_duration_seconds_bucket{route=~\"/broadcasts|/:port/.+|/archive/:slug/.+|/admin/.+\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "5xx %",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "min": 0,
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 73 },
+      "id": 35,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "sortBy": "Last *", "sortDesc": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "API Error Rate (5xx) by Route",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "100 * sum(rate(ccrl_http_request_duration_seconds_count{route=~\"/broadcasts|/:port/.+|/archive/:slug/.+|/admin/.+\", status=~\"5..\"}[5m])) by (route) / sum(rate(ccrl_http_request_duration_seconds_count{route=~\"/broadcasts|/:port/.+|/archive/:slug/.+|/admin/.+\"}[5m])) by (route)",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": {
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "inspect": false
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.25 },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 81 },
+      "id": 36,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": [ { "displayName": "p99 (s)", "desc": true } ]
+      },
+      "title": "Slowest Routes (p99)",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum(rate(ccrl_http_request_duration_seconds_bucket{route!~\"<static>|<unmatched>\"}[5m])) by (le, route))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "__name__": true, "instance": true, "job": true },
+            "indexByName": { "route": 0, "Value": 1 },
+            "renameByName": { "Value": "p99 (s)" }
+          }
+        }
+      ]
     }
   ],
   "refresh": "30s",
@@ -1172,5 +1611,5 @@
   "timezone": "",
   "title": "CCRL Live",
   "uid": "ccrl-live",
-  "version": 1
+  "version": 2
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ import compression from 'compression';
 import serveIndex from 'serve-index';
 import routes from './routes/index.js';
 import adminRoutes from './routes/admin.js';
-import { logging } from './util/index.js';
+import { logging, httpMetrics } from './util/index.js';
 
 export const app = express();
 
@@ -14,6 +14,7 @@ app.set('view engine', 'ejs');
 app.set('views', 'build/views');
 
 app.use(logging);
+app.use(httpMetrics);
 app.use(cors());
 app.use(bp.json());
 app.use(compression());

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,4 +1,4 @@
-import { Counter, Gauge, Registry, collectDefaultMetrics } from 'prom-client';
+import { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
 import broadcasts from './broadcast.js';
 import { getKibitzerManager } from './broadcast-manager.js';
 
@@ -92,6 +92,18 @@ export const kibitzerTargetPort = new Gauge({
       this.set({ id: s.id, engine: s.engineName || 'unknown', type: s.type }, s.targetPort ?? 0);
     }
   },
+});
+
+// --- Histograms (observed at call sites) ---
+
+export const httpRequestDuration = new Histogram({
+  name: 'ccrl_http_request_duration_seconds',
+  help: 'HTTP request duration in seconds, by method, normalized route, and status code',
+  labelNames: ['method', 'route', 'status'] as const,
+  // Web latency: fast in-memory EJS renders (~ms) through filesystem reads and
+  // JSON.parse work (tens to hundreds of ms) up to slow archive reconstruction (1s+).
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [register],
 });
 
 // --- Counters (incremented at call sites) ---

--- a/src/util/http-metrics.ts
+++ b/src/util/http-metrics.ts
@@ -1,0 +1,55 @@
+import { Request, Response, NextFunction } from 'express';
+import onFinished from 'on-finished';
+import { httpRequestDuration } from '../metrics.js';
+
+// Static assets are served from build/public: JS bundles + CSS at the root
+// (main.bundle.js, main.css, …), the img/ and audio/ dirs, favicon, and the /pgns
+// mount. These URLs are unbounded (one path per asset/game), so collapse them all
+// into a single `<static>` label to defend against a cardinality explosion. Match
+// by asset extension + dir so root-level bundles are covered too, not just subdirs.
+const STATIC_PATH = /^\/(img|audio|pgns)(\/|$)|\.(js|mjs|css|map|ico|png|svg|jpe?g|gif|webp|mp3|wav|woff2?|ttf)$/i;
+
+// Reduce a request to a low-cardinality `route` label. Read inside `onFinished`,
+// where routing has completed and `req.route` is populated. `originalPath` is the
+// request path captured at entry — see the note in the middleware on why req.path
+// can't be trusted here.
+const routeLabel = (req: Request, originalPath: string): string => {
+  if (req.route?.path) {
+    // `baseUrl` is the router mount prefix (e.g. "/admin"); `route.path` is the
+    // in-router pattern (e.g. "/:port([0-9]+)/pgn"). Strip Express inline regex
+    // constraints so "/:port([0-9]+)/pgn" -> "/:port/pgn".
+    const raw = (req.baseUrl || '') + req.route.path;
+    const cleaned = raw.replace(/\([^)]*\)/g, '');
+    return cleaned === '' ? '/' : cleaned;
+  }
+
+  // No matched handler: static assets vs the `app.use('*')` catch-all.
+  return STATIC_PATH.test(originalPath) ? '<static>' : '<unmatched>';
+};
+
+export default (req: Request, res: Response, next: NextFunction): void => {
+  // Skip the Prometheus self-scrape (hit every ~30s) and Socket.IO transport
+  // polling — neither is a content route, and both would dominate the per-route
+  // panels and pollute latency.
+  if (req.path === '/admin/metrics' || req.path.startsWith('/socket.io')) {
+    next();
+    return;
+  }
+
+  // Capture the path now: a fall-through to `app.use('*')` rewrites req.url/req.path
+  // by the time `onFinished` fires, so the static-vs-unmatched fallback must
+  // classify against the original path captured here, not the mutated req.path.
+  const originalPath = req.path;
+  const start = process.hrtime.bigint();
+
+  const observe = (): void => {
+    const seconds = Number(process.hrtime.bigint() - start) / 1e9;
+    httpRequestDuration.observe(
+      { method: req.method, route: routeLabel(req, originalPath), status: String(res.statusCode) },
+      seconds,
+    );
+  };
+
+  onFinished(res, observe);
+  next();
+};

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,5 +1,6 @@
 export { default as logger } from './logger.js';
 export { default as logging } from './logging.js';
+export { default as httpMetrics } from './http-metrics.js';
 export { splitOnCommand } from '../protocol.js';
 export { uniqueName } from './unique-name.js';
 export { siteSlug, gameFilenameSlug } from './slugs.js';


### PR DESCRIPTION
## Context

Follow-up to the 2026-05-25 CPU-credit exhaustion incident. The root cause — an expensive `GET /` doing synchronous `JSON.parse` per request — was **invisible to our metrics**: the `ccrl_*` series are all domain gauges/counters with no HTTP request instrumentation, so CPU climbed with nothing pointing at the responsible route. This adds per-route **volume**, **availability**, and **latency (p50/p90/p99)**, and surfaces them in the dashboard.

## What changed

- **`src/metrics.ts`** — new `ccrl_http_request_duration_seconds` histogram, labeled `{method, route, status}`, on the existing shared registry. One histogram covers all three asks: `_count` = volume, `status` label = availability, `_bucket` = latency percentiles (via `histogram_quantile()`).
- **`src/util/http-metrics.ts`** (new) — timing middleware mirroring `logging.ts` (`onFinished`, `process.hrtime`). Normalizes routes to low-cardinality templates (strips Express regex constraints, e.g. `/:port([0-9]+)/pgn` → `/:port/pgn`), collapses assets to `<static>` and unrouted requests to `<unmatched>`, and skips the `/admin/metrics` self-scrape and Socket.IO transport.
- **`src/app.ts` / `src/util/index.ts`** — mount the middleware right after `logging` so it wraps every route, static asset, and the catch-all.
- **`config/grafana-dashboard.json`** — two new rows, **HTTP — Pages** and **HTTP — API** (volume by route, p50/p90/p99 latency, 5xx error-rate, slowest-routes table, plus overall req/s and error% stats). View vs API split via PromQL regex on the `route` label. Dashboard `version` 1 → 2.

## Design notes

- **`status`** is the full code string (bounded set) so 4xx/5xx are distinguishable; `route` is always a template, never a raw value — cardinality stays bounded.
- The original request path is captured at middleware **entry**, because `app.use('*', …)` rewrites `req.path` before `onFinished` fires (would otherwise misclassify static misses).
- The static matcher is **extension-based** because webpack emits bundles/CSS to the `build/public` root, not `/js/`·`/css/` dirs.

## Verification

- `npm run build` → clean (0 TS errors); ESLint clean.
- Ran `dev-server` + `dev-public` against live CCRL broadcasts and drove the UI with Playwright (homepage, a live game page, Chat/Results/Games tabs).
- Scraped `/admin/metrics` and confirmed: every route templated correctly (`/:port`, `/:port/pgn`, `/:port/games/json`, `/:port/result-table/json`, `/broadcasts`, `/`), full `_bucket`/`_sum`/`_count` emit, self-scrape excluded, Socket.IO excluded, and `<static>` vs `<unmatched>` classified correctly for both served and missed assets.

## Note for deploy

The dashboard JSON isn't live until **re-imported** into Grafana (provisioning is empty per the monitoring runbook): Dashboards → Import → overwrite uid `ccrl-live`.