### PR TITLE
feat(theme): add four Claude-branded chess piece sets

### DIFF
--- a/public/img/pieces/CREDITS.md
+++ b/public/img/pieces/CREDITS.md
@@ -8,3 +8,10 @@ lowercase color + uppercase piece, the chessboardjs `{piece}` convention).
   **CC0 / public domain**. Source: https://github.com/kmar/chess_svg_piece_sets
   (added per https://github.com/jhonnold/node-tlcv/issues/162). Upstream files use
   lowercase names (`wk.svg`, `bb.svg`); they were renamed to `wK.svg`/`bB.svg` here.
+- **claude**, **claude_minimal**, **claude_glyph**, **claude_playful** — four
+  Claude-branded sets authored in-repo (no upstream source). All share a coral
+  accent (`#D97757`, Anthropic brand coral) and a 45×45 viewBox matching the
+  classic set. `claude` is a Staunton-style silhouette with an asterisk-style
+  jewel on the king; `claude_minimal` is flat geometric primitives;
+  `claude_glyph` is typographic (SAN letter per piece); `claude_playful` is a
+  cartoony silhouette variant.

--- a/public/img/pieces/claude/bB.svg
+++ b/public/img/pieces/claude/bB.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M 11,40 C 11,37 12,35 14.5,35 L 30.5,35 C 33,35 34,37 34,40 Z"/>
+    <path d="M 15,35 C 16,32 14,30 14,27 C 14,22 18,18 22.5,18 C 27,18 31,22 31,27 C 31,30 29,32 30,35 Z"/>
+    <path d="M 22.5,9 C 21,9 20,10 20,11.5 C 20,12.5 20.5,13 21.5,14 L 22.5,18 L 23.5,14 C 24.5,13 25,12.5 25,11.5 C 25,10 24,9 22.5,9 Z"/>
+    <path d="M 19,27 L 26,27" fill="none" stroke="#ffffff"/>
+  </g>
+  <g fill="#D97757" stroke="none">
+    <rect x="21" y="22" width="3" height="7" rx="0.5"/>
+    <rect x="19" y="24.5" width="7" height="3" rx="0.5"/>
+  </g>
+</svg>

--- a/public/img/pieces/claude/bK.svg
+++ b/public/img/pieces/claude/bK.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M 11,40 C 11,37 12,35 14.5,35 L 30.5,35 C 33,35 34,37 34,40 Z"/>
+    <path d="M 13,35 L 14,22 L 31,22 L 32,35 Z"/>
+    <path d="M 14,22 C 12,20 12,16 14,14 C 16,12 19,12 22.5,16 C 26,12 29,12 31,14 C 33,16 33,20 31,22 Z"/>
+    <path d="M 22.5,9 L 22.5,15" fill="none" stroke="#ffffff"/>
+    <path d="M 19.5,12 L 25.5,12" fill="none" stroke="#ffffff"/>
+    <path d="M 15,28 L 30,28" fill="none" stroke="#ffffff"/>
+  </g>
+  <path d="M 22.5,24 L 23.7,27.3 L 27,28.5 L 23.7,29.7 L 22.5,33 L 21.3,29.7 L 18,28.5 L 21.3,27.3 Z" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude/bN.svg
+++ b/public/img/pieces/claude/bN.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M 11,40 C 11,37 12,35 14.5,35 L 30.5,35 C 33,35 34,37 34,40 Z"/>
+    <path d="M 14,35 L 14,32 C 14,30 16,28 18,27 L 16,24 L 14,22 L 15,19 C 16,16 19,13 22,11 C 25,9 30,9 32,12 C 34,15 34,20 33,24 C 32,27 30,30 31,32 L 31,35 Z"/>
+    <path d="M 17,21 L 19,19" fill="none" stroke="#ffffff"/>
+  </g>
+  <circle cx="27" cy="17" r="1.5" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude/bP.svg
+++ b/public/img/pieces/claude/bP.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <circle cx="22.5" cy="14" r="4.5"/>
+    <path d="M 19.5,18 C 19.5,21 18,22 18,24 L 27,24 C 27,22 25.5,21 25.5,18 Z"/>
+    <path d="M 15,35 C 16,29 21,28 19,24 L 26,24 C 24,28 29,29 30,35 Z"/>
+    <path d="M 11,40 C 11,37 12,35 14.5,35 L 30.5,35 C 33,35 34,37 34,40 Z"/>
+  </g>
+  <circle cx="22.5" cy="14" r="1.6" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude/bQ.svg
+++ b/public/img/pieces/claude/bQ.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M 11,40 C 11,37 12,35 14.5,35 L 30.5,35 C 33,35 34,37 34,40 Z"/>
+    <path d="M 13,35 L 15,22 L 30,22 L 32,35 Z"/>
+    <path d="M 13,22 L 11,12 L 16,19 L 19,10 L 22.5,18 L 26,10 L 29,19 L 34,12 L 32,22 Z"/>
+    <circle cx="11" cy="12" r="2"/>
+    <circle cx="19" cy="10" r="2"/>
+    <circle cx="22.5" cy="8" r="2"/>
+    <circle cx="26" cy="10" r="2"/>
+    <circle cx="34" cy="12" r="2"/>
+    <path d="M 15,26 L 30,26" fill="none" stroke="#ffffff"/>
+  </g>
+  <circle cx="22.5" cy="8" r="1.4" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude/bR.svg
+++ b/public/img/pieces/claude/bR.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M 11,40 C 11,37 12,35 14.5,35 L 30.5,35 C 33,35 34,37 34,40 Z"/>
+    <path d="M 14,35 L 14,20 L 31,20 L 31,35 Z"/>
+    <path d="M 13,20 L 13,17 L 16,17 L 16,14 L 20,14 L 20,17 L 25,17 L 25,14 L 29,14 L 29,17 L 32,17 L 32,20 Z"/>
+    <path d="M 14,32 L 31,32" fill="none" stroke="#ffffff"/>
+    <path d="M 14,24 L 31,24" fill="none" stroke="#ffffff"/>
+  </g>
+  <rect x="21" y="15" width="3" height="3" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude/wB.svg
+++ b/public/img/pieces/claude/wB.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M 11,40 C 11,37 12,35 14.5,35 L 30.5,35 C 33,35 34,37 34,40 Z"/>
+    <path d="M 15,35 C 16,32 14,30 14,27 C 14,22 18,18 22.5,18 C 27,18 31,22 31,27 C 31,30 29,32 30,35 Z"/>
+    <path d="M 22.5,9 C 21,9 20,10 20,11.5 C 20,12.5 20.5,13 21.5,14 L 22.5,18 L 23.5,14 C 24.5,13 25,12.5 25,11.5 C 25,10 24,9 22.5,9 Z"/>
+    <path d="M 19,27 L 26,27" fill="none"/>
+  </g>
+  <g fill="#D97757" stroke="none">
+    <rect x="21" y="22" width="3" height="7" rx="0.5"/>
+    <rect x="19" y="24.5" width="7" height="3" rx="0.5"/>
+  </g>
+</svg>

--- a/public/img/pieces/claude/wK.svg
+++ b/public/img/pieces/claude/wK.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M 11,40 C 11,37 12,35 14.5,35 L 30.5,35 C 33,35 34,37 34,40 Z"/>
+    <path d="M 13,35 L 14,22 L 31,22 L 32,35 Z"/>
+    <path d="M 14,22 C 12,20 12,16 14,14 C 16,12 19,12 22.5,16 C 26,12 29,12 31,14 C 33,16 33,20 31,22 Z"/>
+    <path d="M 22.5,9 L 22.5,15" fill="none"/>
+    <path d="M 19.5,12 L 25.5,12" fill="none"/>
+    <path d="M 15,28 L 30,28" fill="none"/>
+  </g>
+  <path d="M 22.5,24 L 23.7,27.3 L 27,28.5 L 23.7,29.7 L 22.5,33 L 21.3,29.7 L 18,28.5 L 21.3,27.3 Z" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude/wN.svg
+++ b/public/img/pieces/claude/wN.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M 11,40 C 11,37 12,35 14.5,35 L 30.5,35 C 33,35 34,37 34,40 Z"/>
+    <path d="M 14,35 L 14,32 C 14,30 16,28 18,27 L 16,24 L 14,22 L 15,19 C 16,16 19,13 22,11 C 25,9 30,9 32,12 C 34,15 34,20 33,24 C 32,27 30,30 31,32 L 31,35 Z"/>
+    <path d="M 17,21 L 19,19" fill="none"/>
+  </g>
+  <circle cx="27" cy="17" r="1.5" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude/wP.svg
+++ b/public/img/pieces/claude/wP.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <circle cx="22.5" cy="14" r="4.5"/>
+    <path d="M 19.5,18 C 19.5,21 18,22 18,24 L 27,24 C 27,22 25.5,21 25.5,18 Z"/>
+    <path d="M 15,35 C 16,29 21,28 19,24 L 26,24 C 24,28 29,29 30,35 Z"/>
+    <path d="M 11,40 C 11,37 12,35 14.5,35 L 30.5,35 C 33,35 34,37 34,40 Z"/>
+  </g>
+  <circle cx="22.5" cy="14" r="1.6" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude/wQ.svg
+++ b/public/img/pieces/claude/wQ.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M 11,40 C 11,37 12,35 14.5,35 L 30.5,35 C 33,35 34,37 34,40 Z"/>
+    <path d="M 13,35 L 15,22 L 30,22 L 32,35 Z"/>
+    <path d="M 13,22 L 11,12 L 16,19 L 19,10 L 22.5,18 L 26,10 L 29,19 L 34,12 L 32,22 Z"/>
+    <circle cx="11" cy="12" r="2"/>
+    <circle cx="19" cy="10" r="2"/>
+    <circle cx="22.5" cy="8" r="2"/>
+    <circle cx="26" cy="10" r="2"/>
+    <circle cx="34" cy="12" r="2"/>
+    <path d="M 15,26 L 30,26" fill="none"/>
+  </g>
+  <circle cx="22.5" cy="8" r="1.4" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude/wR.svg
+++ b/public/img/pieces/claude/wR.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M 11,40 C 11,37 12,35 14.5,35 L 30.5,35 C 33,35 34,37 34,40 Z"/>
+    <path d="M 14,35 L 14,20 L 31,20 L 31,35 Z"/>
+    <path d="M 13,20 L 13,17 L 16,17 L 16,14 L 20,14 L 20,17 L 25,17 L 25,14 L 29,14 L 29,17 L 32,17 L 32,20 Z"/>
+    <path d="M 14,32 L 31,32" fill="none"/>
+    <path d="M 14,24 L 31,24" fill="none"/>
+  </g>
+  <rect x="21" y="15" width="3" height="3" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_glyph/bB.svg
+++ b/public/img/pieces/claude_glyph/bB.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <text x="22.5" y="33" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="28" fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.2" paint-order="stroke">B</text>
+  <rect x="9" y="36" width="27" height="2.5" rx="1" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_glyph/bK.svg
+++ b/public/img/pieces/claude_glyph/bK.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <text x="22.5" y="33" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="28" fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.2" paint-order="stroke">K</text>
+  <rect x="9" y="36" width="27" height="2.5" rx="1" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_glyph/bN.svg
+++ b/public/img/pieces/claude_glyph/bN.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <text x="22.5" y="33" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="28" fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.2" paint-order="stroke">N</text>
+  <rect x="9" y="36" width="27" height="2.5" rx="1" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_glyph/bP.svg
+++ b/public/img/pieces/claude_glyph/bP.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <text x="22.5" y="33" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="26" fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.2" paint-order="stroke">P</text>
+  <rect x="9" y="36" width="27" height="2.5" rx="1" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_glyph/bQ.svg
+++ b/public/img/pieces/claude_glyph/bQ.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <text x="22.5" y="33" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="28" fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.2" paint-order="stroke">Q</text>
+  <rect x="9" y="36" width="27" height="2.5" rx="1" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_glyph/bR.svg
+++ b/public/img/pieces/claude_glyph/bR.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <text x="22.5" y="33" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="28" fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.2" paint-order="stroke">R</text>
+  <rect x="9" y="36" width="27" height="2.5" rx="1" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_glyph/wB.svg
+++ b/public/img/pieces/claude_glyph/wB.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <text x="22.5" y="33" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="28" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2" paint-order="stroke">B</text>
+  <rect x="9" y="36" width="27" height="2.5" rx="1" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_glyph/wK.svg
+++ b/public/img/pieces/claude_glyph/wK.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <text x="22.5" y="33" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="28" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2" paint-order="stroke">K</text>
+  <rect x="9" y="36" width="27" height="2.5" rx="1" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_glyph/wN.svg
+++ b/public/img/pieces/claude_glyph/wN.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <text x="22.5" y="33" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="28" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2" paint-order="stroke">N</text>
+  <rect x="9" y="36" width="27" height="2.5" rx="1" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_glyph/wP.svg
+++ b/public/img/pieces/claude_glyph/wP.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <text x="22.5" y="33" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="26" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2" paint-order="stroke">P</text>
+  <rect x="9" y="36" width="27" height="2.5" rx="1" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_glyph/wQ.svg
+++ b/public/img/pieces/claude_glyph/wQ.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <text x="22.5" y="33" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="28" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2" paint-order="stroke">Q</text>
+  <rect x="9" y="36" width="27" height="2.5" rx="1" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_glyph/wR.svg
+++ b/public/img/pieces/claude_glyph/wR.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <text x="22.5" y="33" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="28" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.2" paint-order="stroke">R</text>
+  <rect x="9" y="36" width="27" height="2.5" rx="1" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_minimal/bB.svg
+++ b/public/img/pieces/claude_minimal/bB.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <rect x="10" y="37" width="25" height="4" rx="0.5"/>
+    <path d="M 22.5,10 L 33,37 L 12,37 Z"/>
+  </g>
+  <g fill="#D97757">
+    <rect x="21" y="18" width="3" height="9" rx="0.5"/>
+    <rect x="18" y="21" width="9" height="3" rx="0.5"/>
+  </g>
+</svg>

--- a/public/img/pieces/claude_minimal/bK.svg
+++ b/public/img/pieces/claude_minimal/bK.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <rect x="10" y="37" width="25" height="4" rx="0.5"/>
+    <path d="M 14,22 L 31,22 L 30,37 L 15,37 Z"/>
+    <rect x="20.75" y="9" width="3.5" height="11"/>
+    <rect x="17" y="13" width="11" height="3.5"/>
+  </g>
+  <circle cx="22.5" cy="14.75" r="1.7" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_minimal/bN.svg
+++ b/public/img/pieces/claude_minimal/bN.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <rect x="10" y="37" width="25" height="4" rx="0.5"/>
+    <path d="M 12,37 L 12,32 L 15,24 L 19,17 L 26,12 L 33,15 L 34,22 L 33,28 L 30,32 L 30,37 Z"/>
+    <path d="M 16,22 L 21,18" fill="none" stroke="#ffffff"/>
+  </g>
+  <circle cx="28" cy="19" r="1.4" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_minimal/bP.svg
+++ b/public/img/pieces/claude_minimal/bP.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <circle cx="22.5" cy="18" r="5"/>
+    <path d="M 14,37 L 31,37 L 28,24 L 17,24 Z"/>
+    <rect x="10" y="37" width="25" height="4" rx="0.5"/>
+  </g>
+  <circle cx="22.5" cy="18" r="1.8" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_minimal/bQ.svg
+++ b/public/img/pieces/claude_minimal/bQ.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <rect x="10" y="37" width="25" height="4" rx="0.5"/>
+    <path d="M 14,22 L 31,22 L 29,37 L 16,37 Z"/>
+    <circle cx="13" cy="18" r="2.6"/>
+    <circle cx="18" cy="15" r="2.6"/>
+    <circle cx="22.5" cy="13" r="2.6"/>
+    <circle cx="27" cy="15" r="2.6"/>
+    <circle cx="32" cy="18" r="2.6"/>
+  </g>
+  <circle cx="22.5" cy="13" r="1.8" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_minimal/bR.svg
+++ b/public/img/pieces/claude_minimal/bR.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <rect x="10" y="37" width="25" height="4" rx="0.5"/>
+    <rect x="13" y="20" width="19" height="17"/>
+    <rect x="13" y="13" width="4.5" height="7"/>
+    <rect x="20.25" y="13" width="4.5" height="7"/>
+    <rect x="27.5" y="13" width="4.5" height="7"/>
+  </g>
+  <rect x="20.75" y="14.5" width="3.5" height="4" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_minimal/wB.svg
+++ b/public/img/pieces/claude_minimal/wB.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <rect x="10" y="37" width="25" height="4" rx="0.5"/>
+    <path d="M 22.5,10 L 33,37 L 12,37 Z"/>
+  </g>
+  <g fill="#D97757">
+    <rect x="21" y="18" width="3" height="9" rx="0.5"/>
+    <rect x="18" y="21" width="9" height="3" rx="0.5"/>
+  </g>
+</svg>

--- a/public/img/pieces/claude_minimal/wK.svg
+++ b/public/img/pieces/claude_minimal/wK.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <rect x="10" y="37" width="25" height="4" rx="0.5"/>
+    <path d="M 14,22 L 31,22 L 30,37 L 15,37 Z"/>
+    <rect x="20.75" y="9" width="3.5" height="11"/>
+    <rect x="17" y="13" width="11" height="3.5"/>
+  </g>
+  <circle cx="22.5" cy="14.75" r="1.7" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_minimal/wN.svg
+++ b/public/img/pieces/claude_minimal/wN.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <rect x="10" y="37" width="25" height="4" rx="0.5"/>
+    <path d="M 12,37 L 12,32 L 15,24 L 19,17 L 26,12 L 33,15 L 34,22 L 33,28 L 30,32 L 30,37 Z"/>
+    <path d="M 16,22 L 21,18" fill="none"/>
+  </g>
+  <circle cx="28" cy="19" r="1.4" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_minimal/wP.svg
+++ b/public/img/pieces/claude_minimal/wP.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <circle cx="22.5" cy="18" r="5"/>
+    <path d="M 14,37 L 31,37 L 28,24 L 17,24 Z"/>
+    <rect x="10" y="37" width="25" height="4" rx="0.5"/>
+  </g>
+  <circle cx="22.5" cy="18" r="1.8" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_minimal/wQ.svg
+++ b/public/img/pieces/claude_minimal/wQ.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <rect x="10" y="37" width="25" height="4" rx="0.5"/>
+    <path d="M 14,22 L 31,22 L 29,37 L 16,37 Z"/>
+    <circle cx="13" cy="18" r="2.6"/>
+    <circle cx="18" cy="15" r="2.6"/>
+    <circle cx="22.5" cy="13" r="2.6"/>
+    <circle cx="27" cy="15" r="2.6"/>
+    <circle cx="32" cy="18" r="2.6"/>
+  </g>
+  <circle cx="22.5" cy="13" r="1.8" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_minimal/wR.svg
+++ b/public/img/pieces/claude_minimal/wR.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <rect x="10" y="37" width="25" height="4" rx="0.5"/>
+    <rect x="13" y="20" width="19" height="17"/>
+    <rect x="13" y="13" width="4.5" height="7"/>
+    <rect x="20.25" y="13" width="4.5" height="7"/>
+    <rect x="27.5" y="13" width="4.5" height="7"/>
+  </g>
+  <rect x="20.75" y="14.5" width="3.5" height="4" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_playful/bB.svg
+++ b/public/img/pieces/claude_playful/bB.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <ellipse cx="22.5" cy="40" rx="13" ry="2.5"/>
+    <path d="M 14,38 C 14,32 16,28 18,26 C 16,24 14,21 14,18 C 14,12 18,8 22.5,8 C 27,8 31,12 31,18 C 31,21 29,24 27,26 C 29,28 31,32 31,38 Z"/>
+    <circle cx="22.5" cy="9" r="1.6"/>
+  </g>
+  <g fill="#D97757" stroke="none">
+    <rect x="21" y="20" width="3" height="10" rx="0.7"/>
+    <rect x="18" y="23.5" width="9" height="3" rx="0.7"/>
+  </g>
+</svg>

--- a/public/img/pieces/claude_playful/bK.svg
+++ b/public/img/pieces/claude_playful/bK.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <ellipse cx="22.5" cy="40" rx="13" ry="2.5"/>
+    <path d="M 13,38 C 13,30 16,26 18,24 L 27,24 C 29,26 32,30 32,38 Z"/>
+    <path d="M 13,24 C 11,22 11,16 14,14 C 17,12 21,13 22.5,17 C 24,13 28,12 31,14 C 34,16 34,22 32,24 Z"/>
+    <path d="M 22.5,7 L 22.5,15" fill="none" stroke="#ffffff"/>
+    <path d="M 18.5,11 L 26.5,11" fill="none" stroke="#ffffff"/>
+  </g>
+  <path d="M 22.5,27 L 24,30 L 27.5,30.5 L 25,33 L 25.5,36.5 L 22.5,34.5 L 19.5,36.5 L 20,33 L 17.5,30.5 L 21,30 Z" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_playful/bN.svg
+++ b/public/img/pieces/claude_playful/bN.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <ellipse cx="22.5" cy="40" rx="13" ry="2.5"/>
+    <path d="M 12,38 C 12,33 14,30 17,28 C 14,26 13,22 14,18 C 15,14 19,11 24,10 C 29,10 33,13 34,18 C 35,24 33,30 31,32 C 30,34 31,36 31,38 Z"/>
+    <path d="M 16,21 C 17,18 19,17 19,17" fill="none" stroke="#ffffff"/>
+  </g>
+  <circle cx="27" cy="19" r="1.7" fill="#D97757"/>
+  <path d="M 26,24 Q 28,26 30,24" fill="none" stroke="#D97757" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/public/img/pieces/claude_playful/bP.svg
+++ b/public/img/pieces/claude_playful/bP.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <ellipse cx="22.5" cy="40" rx="13" ry="2.5"/>
+    <path d="M 14,38 C 14,30 18,26 22.5,25 C 27,26 31,30 31,38 Z"/>
+    <circle cx="22.5" cy="17" r="6"/>
+  </g>
+  <circle cx="20" cy="18" r="1.2" fill="#D97757"/>
+  <circle cx="25" cy="18" r="1.2" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_playful/bQ.svg
+++ b/public/img/pieces/claude_playful/bQ.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <ellipse cx="22.5" cy="40" rx="13" ry="2.5"/>
+    <path d="M 13,38 C 13,30 16,26 18,24 L 27,24 C 29,26 32,30 32,38 Z"/>
+    <path d="M 14,24 L 11,12 L 16,18 L 19,9 L 22.5,17 L 26,9 L 29,18 L 34,12 L 31,24 Z"/>
+    <circle cx="11" cy="12" r="2.3"/>
+    <circle cx="19" cy="9" r="2.3"/>
+    <circle cx="22.5" cy="7" r="2.3"/>
+    <circle cx="26" cy="9" r="2.3"/>
+    <circle cx="34" cy="12" r="2.3"/>
+  </g>
+  <circle cx="22.5" cy="7" r="1.6" fill="#D97757"/>
+  <circle cx="22.5" cy="30" r="1.7" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_playful/bR.svg
+++ b/public/img/pieces/claude_playful/bR.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <ellipse cx="22.5" cy="40" rx="13" ry="2.5"/>
+    <path d="M 12,38 L 12,20 Q 12,18 14,18 L 31,18 Q 33,18 33,20 L 33,38 Z"/>
+    <path d="M 11,18 L 11,13 Q 11,12 12,12 L 16,12 Q 17,12 17,13 L 17,15 L 21,15 L 21,13 Q 21,12 22,12 L 23,12 Q 24,12 24,13 L 24,15 L 28,15 L 28,13 Q 28,12 29,12 L 33,12 Q 34,12 34,13 L 34,18 Z"/>
+  </g>
+  <circle cx="22.5" cy="27" r="2.2" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_playful/wB.svg
+++ b/public/img/pieces/claude_playful/wB.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <ellipse cx="22.5" cy="40" rx="13" ry="2.5"/>
+    <path d="M 14,38 C 14,32 16,28 18,26 C 16,24 14,21 14,18 C 14,12 18,8 22.5,8 C 27,8 31,12 31,18 C 31,21 29,24 27,26 C 29,28 31,32 31,38 Z"/>
+    <circle cx="22.5" cy="9" r="1.6"/>
+  </g>
+  <g fill="#D97757" stroke="none">
+    <rect x="21" y="20" width="3" height="10" rx="0.7"/>
+    <rect x="18" y="23.5" width="9" height="3" rx="0.7"/>
+  </g>
+</svg>

--- a/public/img/pieces/claude_playful/wK.svg
+++ b/public/img/pieces/claude_playful/wK.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <ellipse cx="22.5" cy="40" rx="13" ry="2.5"/>
+    <path d="M 13,38 C 13,30 16,26 18,24 L 27,24 C 29,26 32,30 32,38 Z"/>
+    <path d="M 13,24 C 11,22 11,16 14,14 C 17,12 21,13 22.5,17 C 24,13 28,12 31,14 C 34,16 34,22 32,24 Z"/>
+    <path d="M 22.5,7 L 22.5,15" fill="none"/>
+    <path d="M 18.5,11 L 26.5,11" fill="none"/>
+  </g>
+  <path d="M 22.5,27 L 24,30 L 27.5,30.5 L 25,33 L 25.5,36.5 L 22.5,34.5 L 19.5,36.5 L 20,33 L 17.5,30.5 L 21,30 Z" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_playful/wN.svg
+++ b/public/img/pieces/claude_playful/wN.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <ellipse cx="22.5" cy="40" rx="13" ry="2.5"/>
+    <path d="M 12,38 C 12,33 14,30 17,28 C 14,26 13,22 14,18 C 15,14 19,11 24,10 C 29,10 33,13 34,18 C 35,24 33,30 31,32 C 30,34 31,36 31,38 Z"/>
+    <path d="M 16,21 C 17,18 19,17 19,17" fill="none"/>
+  </g>
+  <circle cx="27" cy="19" r="1.7" fill="#D97757"/>
+  <path d="M 26,24 Q 28,26 30,24" fill="none" stroke="#D97757" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/public/img/pieces/claude_playful/wP.svg
+++ b/public/img/pieces/claude_playful/wP.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <ellipse cx="22.5" cy="40" rx="13" ry="2.5"/>
+    <path d="M 14,38 C 14,30 18,26 22.5,25 C 27,26 31,30 31,38 Z"/>
+    <circle cx="22.5" cy="17" r="6"/>
+  </g>
+  <circle cx="20" cy="18" r="1.2" fill="#D97757"/>
+  <circle cx="25" cy="18" r="1.2" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_playful/wQ.svg
+++ b/public/img/pieces/claude_playful/wQ.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <ellipse cx="22.5" cy="40" rx="13" ry="2.5"/>
+    <path d="M 13,38 C 13,30 16,26 18,24 L 27,24 C 29,26 32,30 32,38 Z"/>
+    <path d="M 14,24 L 11,12 L 16,18 L 19,9 L 22.5,17 L 26,9 L 29,18 L 34,12 L 31,24 Z"/>
+    <circle cx="11" cy="12" r="2.3"/>
+    <circle cx="19" cy="9" r="2.3"/>
+    <circle cx="22.5" cy="7" r="2.3"/>
+    <circle cx="26" cy="9" r="2.3"/>
+    <circle cx="34" cy="12" r="2.3"/>
+  </g>
+  <circle cx="22.5" cy="7" r="1.6" fill="#D97757"/>
+  <circle cx="22.5" cy="30" r="1.7" fill="#D97757"/>
+</svg>

--- a/public/img/pieces/claude_playful/wR.svg
+++ b/public/img/pieces/claude_playful/wR.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 45 45">
+  <g fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round">
+    <ellipse cx="22.5" cy="40" rx="13" ry="2.5"/>
+    <path d="M 12,38 L 12,20 Q 12,18 14,18 L 31,18 Q 33,18 33,20 L 33,38 Z"/>
+    <path d="M 11,18 L 11,13 Q 11,12 12,12 L 16,12 Q 17,12 17,13 L 17,15 L 21,15 L 21,13 Q 21,12 22,12 L 23,12 Q 24,12 24,13 L 24,15 L 28,15 L 28,13 Q 28,12 29,12 L 33,12 Q 34,12 34,13 L 34,18 Z"/>
+  </g>
+  <circle cx="22.5" cy="27" r="2.2" fill="#D97757"/>
+</svg>

--- a/public/js/components/theme/piece-sets.ts
+++ b/public/js/components/theme/piece-sets.ts
@@ -6,7 +6,15 @@
 // chessboardjs token (`wK`…`bP`). DEFAULT_PIECE_SET below must stay in sync with
 // the pre-JS fallback path hardcoded in views/pages/broadcasts.ejs.
 
-export type PieceSetId = 'classic' | 'livius' | 'meridian' | 'meridian_shaded';
+export type PieceSetId =
+  | 'classic'
+  | 'livius'
+  | 'meridian'
+  | 'meridian_shaded'
+  | 'claude'
+  | 'claude_minimal'
+  | 'claude_glyph'
+  | 'claude_playful';
 
 export interface PieceSetMeta {
   id: PieceSetId;
@@ -19,6 +27,10 @@ export const PIECE_SETS: PieceSetMeta[] = [
   { id: 'livius', label: 'Livius' },
   { id: 'meridian', label: 'Meridian' },
   { id: 'meridian_shaded', label: 'Meridian Shaded' },
+  { id: 'claude', label: 'Claude' },
+  { id: 'claude_minimal', label: 'Claude Minimal' },
+  { id: 'claude_glyph', label: 'Claude Glyph' },
+  { id: 'claude_playful', label: 'Claude Playful' },
 ];
 
 export const DEFAULT_PIECE_SET: PieceSetId = 'classic';


### PR DESCRIPTION
## Summary

Adds four new in-repo chess piece sets to the Theme → Pieces selector:

- **Claude** — Staunton-style silhouette; king carries a coral 4-point asterisk on the body.
- **Claude Minimal** — Flat geometric primitives (circles, rects, polygons) with a single coral accent per piece.
- **Claude Glyph** — Typographic: each piece is its SAN letter (K/Q/R/B/N/P) in bold Georgia over a coral underline.
- **Claude Playful** — Rounded cartoony silhouettes (pawn has coral cheeks, knight a coral eye + smile, king a coral star).

All 48 SVGs are hand-written (no upstream source), share the coral accent `#D97757`, and use the classic `45×45` `viewBox` so they scale identically to the existing sets — no meridian-style scaling shim needed.

Registry: `public/js/components/theme/piece-sets.ts` `PieceSetId` union and `PIECE_SETS` array extended with the four new entries. Every consumer (`board/`, theme modal, `pieceSrc()`) already reads from this registry, so no other code changes were required. `DEFAULT_PIECE_SET` stays `'classic'`, so the pre-JS fallback path in `views/pages/broadcasts.ejs` is unaffected. `public/img/pieces/CREDITS.md` updated with attribution.

## Test plan

- [x] `npm run build` (TypeScript + webpack) clean
- [x] Backend live test against broadcast `16065` with `dev-server` + `dev-public`
- [ ] Theme → Pieces dropdown lists 8 sets in declared order
- [ ] Each of the 4 new sets renders all 12 pieces on the main board with a visible coral accent
- [ ] Mini-boards (Games tab) and Replay view honor the selected set
- [ ] `localStorage.tlcv.pieceSet` persists across reloads
- [ ] Existing 4 sets (`classic`, `livius`, `meridian`, `meridian_shaded`) unchanged