### PR TITLE
feat: add Lichess dependency metrics + Grafana panels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,8 @@ Prometheus metrics via `prom-client`. `src/metrics.ts` owns a single `Registry` 
 
 **Gauges** (recomputed at scrape time via `collect()`): `ccrl_broadcasts_active`, `ccrl_broadcast_spectators`, `ccrl_broadcast_browser_connections`, `ccrl_game_move_number`, `ccrl_kibitzer_total`, `ccrl_kibitzer_ready`, `ccrl_kibitzer_target_port` (labeled by `port`/`event`).
 
+**Histograms** (observed at call sites): `ccrl_http_request_duration_seconds` (labels `method`/`route`/`status`, instrumented in `util/http-metrics.ts`), `ccrl_lichess_request_duration_seconds` (labels `endpoint`/`outcome`, instrumented in `services/lichess.ts` — wraps `fetchOpening` and `fetchTablebase`).
+
 **Counters** (incremented inline at the event site): `ccrl_udp_messages_received_total`, `ccrl_udp_messages_out_of_order_total`, `ccrl_commands_processed_total`, `ccrl_chat_messages_total`, `ccrl_spectator_joins_total`, `ccrl_spectator_leaves_total`, `ccrl_socket_emissions_total`, `ccrl_kibitzer_assignments_total`, `ccrl_message_buffer_errors_total`.
 
 Instrumented across `game-service.ts` (commands, chat), `socket-io-adapter.ts` (spectator join/leave, emissions), `transport/udp-transport.ts` (UDP receive, out-of-order), `transport/message-buffer.ts` (buffer errors), and `kibitzer/kibitzer-manager.ts` (assignments). Counters import the specific metric and call `.inc()`; gauges read live state (`broadcasts` map, `KibitzerManager`) at scrape time, so no per-event wiring is needed for them.

--- a/config/grafana-dashboard.json
+++ b/config/grafana-dashboard.json
@@ -1600,6 +1600,224 @@
           }
         }
       ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 89 },
+      "id": 109,
+      "title": "External Dependencies (Lichess)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "req/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "min": 0,
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 90 },
+      "id": 37,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "sortBy": "Last *", "sortDesc": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Lichess Request Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (endpoint, outcome) (rate(ccrl_lichess_request_duration_seconds_count[5m]))",
+          "legendFormat": "{{endpoint}} / {{outcome}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "error ratio",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "min": 0,
+          "max": 1,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 90 },
+      "id": 38,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Lichess Error Ratio",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (endpoint) (rate(ccrl_lichess_request_duration_seconds_count{outcome=\"error\"}[5m])) / sum by (endpoint) (rate(ccrl_lichess_request_duration_seconds_count[5m]))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "latency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "p99" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 98 },
+      "id": 39,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Opening Latency (p50 / p90 / p99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(ccrl_lichess_request_duration_seconds_bucket{endpoint=\"opening\",outcome=\"success\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(ccrl_lichess_request_duration_seconds_bucket{endpoint=\"opening\",outcome=\"success\"}[5m])))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(ccrl_lichess_request_duration_seconds_bucket{endpoint=\"opening\",outcome=\"success\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "latency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "p99" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 98 },
+      "id": 40,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Tablebase Latency (p50 / p90 / p99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(ccrl_lichess_request_duration_seconds_bucket{endpoint=\"tablebase\",outcome=\"success\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(ccrl_lichess_request_duration_seconds_bucket{endpoint=\"tablebase\",outcome=\"success\"}[5m])))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(ccrl_lichess_request_duration_seconds_bucket{endpoint=\"tablebase\",outcome=\"success\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
     }
   ],
   "refresh": "30s",
@@ -1611,5 +1829,5 @@
   "timezone": "",
   "title": "CCRL Live",
   "uid": "ccrl-live",
-  "version": 2
+  "version": 3
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -106,6 +106,15 @@ export const httpRequestDuration = new Histogram({
   registers: [register],
 });
 
+export const lichessRequestDuration = new Histogram({
+  name: 'ccrl_lichess_request_duration_seconds',
+  help: 'Lichess API request duration in seconds, by endpoint and outcome',
+  labelNames: ['endpoint', 'outcome'] as const,
+  // External HTTP: ~50ms warm to multi-second on Lichess slow paths; cap at 30s.
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30],
+  registers: [register],
+});
+
 // --- Counters (incremented at call sites) ---
 
 export const udpMessagesReceived = new Counter({

--- a/src/services/lichess.ts
+++ b/src/services/lichess.ts
@@ -1,5 +1,6 @@
 import { Chess } from 'chess.js';
 import type { ColorCode } from '../../shared/types.js';
+import { lichessRequestDuration } from '../metrics.js';
 import { logger } from '../util/index.js';
 
 export type LichessExplorerResponse = {
@@ -21,6 +22,7 @@ export async function fetchOpening(name: string, instance: Chess): Promise<Openi
 
   logger.info(`Requesting opening for game ${name} from ${url}`, { port: name });
 
+  const endTimer = lichessRequestDuration.startTimer({ endpoint: 'opening' });
   try {
     const headers: HeadersInit = { 'Content-Type': 'application/json' };
     if (process.env.LICHESS_OAUTH_TOKEN) {
@@ -37,11 +39,14 @@ export async function fetchOpening(name: string, instance: Chess): Promise<Openi
       const { eco, name: openingName } = opening;
 
       logger.info(`Setting opening for game ${name} to ${eco} ${openingName}`, { port: name });
+      endTimer({ outcome: 'success' });
       return { failed: false, opening: `${eco} ${openingName}` };
     }
 
+    endTimer({ outcome: 'success' });
     return { failed: false, opening: null };
   } catch (error) {
+    endTimer({ outcome: 'error' });
     logger.warn(`Error requesting opening for game ${name} @ ${url}`, { port: name });
     logger.error(error);
     return { failed: true, opening: null };
@@ -53,6 +58,7 @@ export async function fetchTablebase(name: string, fen: string, turn: ColorCode)
 
   logger.info(`Requesting tablebase for game ${name} from ${url}`, { port: name });
 
+  const endTimer = lichessRequestDuration.startTimer({ endpoint: 'tablebase' });
   try {
     const response = await fetch(url, {
       method: 'GET',
@@ -97,12 +103,15 @@ export async function fetchTablebase(name: string, fen: string, turn: ColorCode)
       }
 
       logger.info(`Set tablebase for game ${name} to ${result}`, { port: name });
+      endTimer({ outcome: 'success' });
       return result;
     } else {
       logger.info(`Setting tablebase for game ${name} to blank`, { port: name });
+      endTimer({ outcome: 'success' });
       return '';
     }
   } catch (error) {
+    endTimer({ outcome: 'error' });
     logger.warn(`Error requesting tablebase for game ${name} @ ${url}`, { port: name });
     logger.error(error);
     return '';


### PR DESCRIPTION
## Summary
- Add Prometheus Histogram `ccrl_lichess_request_duration_seconds` (labels: `endpoint`, `outcome`) wrapping `fetchOpening` and `fetchTablebase` in `src/services/lichess.ts`.
- Add an **External Dependencies (Lichess)** row to `config/grafana-dashboard.json` with four panels: request rate by endpoint+outcome, error ratio, opening latency (p50/p90/p99), tablebase latency (p50/p90/p99).
- Document the new metric in `CLAUDE.md` (added a Histograms line covering both the existing HTTP histogram and this one).

## Motivation
A recent multi-hour Lichess failure (TLS-chain change combined with a stale snap-node revision pinned to the running process) made every `fetchOpening` / `fetchTablebase` call fail. The viewer showed `unknown` openings across all broadcasts for hours, and the only signal was log warnings — no dashboard panel, no alertable signal. This PR closes that gap. The error-ratio panel would have screamed during that outage and makes it trivial to add an alert later once a sensible threshold has been observed.

## Design notes
- Single Histogram (not two metrics) with an `endpoint` label, keeping cardinality flat (~52 series total).
- `outcome="success"` includes the "no opening matched" case (`opening: null`) since that's a normal API answer, not a failure.
- Latency-percentile panels filter on `outcome="success"` so failed-fast errors don't pollute the curves.
- Mirrors the existing `ccrl_http_request_duration_seconds` instrumentation pattern (in `src/util/http-metrics.ts`); reuses `prom-client` `startTimer` / `endTimer({outcome})` for clean two-branch observation.
- No new alert rules — explicitly out of scope. Add in Grafana after the metric has settled.

## Test plan
- [x] `npm run build` — clean (TS + webpack)
- [x] Dashboard JSON parses
- [x] Programmatically exercised the histogram: both `{endpoint=opening,outcome=success}` and `{endpoint=tablebase,outcome=error}` series appear with correct buckets, `_sum`, and `_count`.
- [ ] Deploy to prod (`stash → pull → pop → npm run build → systemctl restart tlcv`), verify `curl -u admin:\$TLCV_PASSWORD .../admin/metrics | grep ccrl_lichess` shows live data after the next move on any broadcast.
- [ ] Re-import `config/grafana-dashboard.json` (overwrite uid `ccrl-live`) and confirm the four new panels render.