### PR TITLE
feat: reintroduce cached Previous Broadcasts on homepage

### DIFF
--- a/src/broadcast-manager.ts
+++ b/src/broadcast-manager.ts
@@ -1,6 +1,7 @@
 import dns from 'dns';
 import broadcasts, { Broadcast } from './broadcast.js';
 import configStore from './config/config-store.js';
+import { invalidateListingCache } from './services/tournament-results.js';
 import type { KibitzerManager } from './kibitzer/kibitzer-manager.js';
 import type { WebhookManager } from './webhooks/webhook-manager.js';
 
@@ -54,6 +55,10 @@ export async function closeConnection(connection: string): Promise<void> {
   if (!broadcast) throw Error('Invalid port!');
   broadcast.close();
   broadcasts.delete(+port);
+
+  // The closed broadcast's tournament drops out of the live set and should now appear
+  // in the homepage "Previous Broadcasts" listing with its final stats — re-scan once.
+  invalidateListingCache();
 
   await configStore.removeConnection(connection);
 }

--- a/src/game-service.ts
+++ b/src/game-service.ts
@@ -7,7 +7,11 @@ import { fetchOpening, fetchTablebase } from './services/lichess.js';
 import type { OpeningResult } from './services/lichess.js';
 import { savePgn } from './services/pgn.js';
 import { saveGameMeta, invalidate as invalidateMetaCache } from './services/game-meta.js';
-import { saveTournamentResults, invalidateArchiveCache } from './services/tournament-results.js';
+import {
+  saveTournamentResults,
+  invalidateArchiveCache,
+  invalidateListingCache,
+} from './services/tournament-results.js';
 import { invalidate as invalidatePgnCache } from './services/pgn-cache.js';
 import { Command, splitOnCommand } from './protocol.js';
 import { EmitType } from './socket-io-adapter.js';
@@ -360,6 +364,10 @@ class GameService {
       invalidateArchiveCache(oldSlug);
     }
     this.game.site = site.replace('GrahamCCRL.dyndns.org\\', '').replace(/\.[\w]+$/, '');
+
+    // A site change moves the old slug out of the live set (it becomes archived) and a
+    // new pgns/<slug>/ folder may appear, so the homepage listing scan must re-run.
+    invalidateListingCache();
 
     logger.info(`Updated game ${this.game.name} - Site: ${this.game.site}`, { port: this.broadcast.port });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,13 +10,16 @@ import { KibitzerManager } from './kibitzer/index.js';
 import { WebhookManager } from './webhooks/index.js';
 import { loadAll as loadPgnCache } from './services/pgn-cache.js';
 import { loadAll as loadMetaCache } from './services/game-meta.js';
+import { listArchivedTournaments } from './services/tournament-results.js';
 import configStore from './config/config-store.js';
 
 const server = http.createServer(app);
 io.attach(server);
 
 (async () => {
-  await Promise.all([loadPgnCache(), loadMetaCache()]);
+  // Warm the homepage archive-listing cache alongside the file caches so the first
+  // `/` hit does no disk scan. listArchivedTournaments() resolves to [] on error.
+  await Promise.all([loadPgnCache(), loadMetaCache(), listArchivedTournaments()]);
 
   const config = await configStore.load();
   const kibitzers = config.kibitzers ?? [];

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,7 +3,7 @@ import broadcasts, { Broadcast } from '../broadcast.js';
 import { siteSlug } from '../util/index.js';
 import { getFiles } from '../services/pgn-cache.js';
 import { getMetaFile, getMetaFileUrl } from '../services/game-meta.js';
-import { loadOrReconstructArchive } from '../services/tournament-results.js';
+import { listArchivedTournaments, loadOrReconstructArchive } from '../services/tournament-results.js';
 import type { GameRecord, StoredTournamentResults } from '../../shared/types.js';
 
 interface RequestWithBroadcast extends Request {
@@ -55,16 +55,16 @@ router.get('/', async (_: Request, res: Response): Promise<void> => {
     })
     .sort((a, b) => b.viewerCount - a.viewerCount);
 
-  // NOTE: the "Previous Broadcasts" archive listing was removed from the homepage.
-  // listArchivedTournaments() read+parsed every pgns/*/tournament-results.json and
-  // scanned meta-only folders on every `/` hit — uncached, synchronous JSON.parse on
-  // the site's most-trafficked route, which drained the host's CPU credits. Tournament
-  // data is still persisted (saveTournamentResults) and reachable via /archive/:slug.
-  // We still pass `archived: []` because broadcasts.ejs references the variable under
-  // EJS's `with(locals)` scope — omitting it entirely throws a ReferenceError. The
-  // empty array makes the template's `archived && archived.length` guard hide the
-  // section. Re-enable via a cached listing if/when needed.
-  res.render('pages/broadcasts', { broadcasts: broadcastList, archived: [] });
+  // "Previous Broadcasts": archived tournaments excluding currently-live ones (those
+  // already appear above). listArchivedTournaments() is cached — the disk scan only
+  // re-runs on a live->archived transition (see tournament-results.ts), so this route
+  // does no per-request disk I/O when warm. The liveSlugs filter stays per-request
+  // because the live set changes independently of the cached scan; it's a cheap
+  // in-memory Set lookup over the broadcasts map.
+  const liveSlugs = new Set(Array.from(broadcasts.values()).map((b) => siteSlug(b.game.site)));
+  const archived = (await listArchivedTournaments()).filter((t) => !liveSlugs.has(t.slug));
+
+  res.render('pages/broadcasts', { broadcasts: broadcastList, archived });
 });
 
 router.get('/broadcasts', (_: Request, res: Response): void => {

--- a/src/services/tournament-results.ts
+++ b/src/services/tournament-results.ts
@@ -17,6 +17,25 @@ export function invalidateArchiveCache(slug: string): void {
   archiveCache.delete(slug);
 }
 
+// The homepage archive listing scans every pgns/* folder (readdir + JSON.parse of
+// each results.json) — too expensive to run per request on the busiest, auto-
+// refreshing route (see the 2026-05-25 CPU-credit incident). Cache the full scan
+// result and only re-scan on a live->archived transition (closeConnection / onSite),
+// never on the per-game-finish results.json write: that write only touches *live*
+// tournaments, which are filtered out of the listing, so a displayed entry's file is
+// already frozen. `listingInflight` coalesces concurrent cold-cache scans into one.
+let listingCache: ArchiveSummary[] | null = null;
+let listingInflight: Promise<ArchiveSummary[]> | null = null;
+
+export function invalidateListingCache(): void {
+  // Clearing the in-flight promise too forces the next caller to start a fresh scan
+  // rather than reuse one that began before this mutation. A scan already running
+  // still resolves and may briefly repopulate slightly-stale data — acceptable for a
+  // non-critical listing, and the triggering mutation is rare.
+  listingCache = null;
+  listingInflight = null;
+}
+
 export async function saveTournamentResults(broadcast: Broadcast): Promise<void> {
   // Fire-and-forget from the message loop, so the whole body is guarded — a throw
   // anywhere (slug/path construction included) must never become an unhandled rejection.
@@ -103,7 +122,30 @@ async function dirUpdatedAt(slug: string): Promise<string> {
   }
 }
 
+// Public, cached entry point. Returns the cached scan when warm; otherwise runs a
+// single scan shared by all concurrent callers (cold-cache stampede guard). A thrown
+// scan resolves to [] without poisoning the cache, so the next call retries.
 export async function listArchivedTournaments(): Promise<ArchiveSummary[]> {
+  if (listingCache) return listingCache;
+  if (listingInflight) return listingInflight;
+
+  listingInflight = scanArchivedTournaments()
+    .then((summaries) => {
+      listingCache = summaries;
+      return summaries;
+    })
+    .catch((error) => {
+      logger.error(`Unable to list archived tournaments! - ${error}`);
+      return [];
+    })
+    .finally(() => {
+      listingInflight = null;
+    });
+
+  return listingInflight;
+}
+
+async function scanArchivedTournaments(): Promise<ArchiveSummary[]> {
   let entries: Dirent[];
   try {
     entries = await fs.readdir('pgns', { withFileTypes: true });


### PR DESCRIPTION
## Summary

Restores the **Previous Broadcasts** archive listing on the homepage `GET /`, removed in `9b3c5fb` after it drained the host's CPU credits. This time the expensive disk scan is cached, so the homepage does **zero disk I/O / `JSON.parse`** when warm.

### Background

`listArchivedTournaments()` did an uncached `readdir('pgns')` + synchronous `JSON.parse` of every `pgns/*/tournament-results.json` on **every** `/` request — the busiest route, which also auto-refreshes every 30s (`<meta http-equiv="refresh">`), so each open tab re-hit it twice a minute. On the burstable T-class host (~0.2 vCPU baseline, little headroom) this exhausted CPU credits. Full postmortem in the internal incident notes.

Since tournaments finish **at most once a day**, this is highly cacheable.

## Changes

- **`tournament-results.ts`** — cache the full archive scan (`listingCache`) with a shared in-flight promise that coalesces concurrent cold-cache scans (guards against the 30s-refresh stampede). Split `listArchivedTournaments()` into a private `scanArchivedTournaments()` + a cached public wrapper that resolves to `[]` on error without poisoning the cache. New `invalidateListingCache()` export.
- **`routes/index.ts`** — restore the live-filtered listing in `GET /`. The cheap `liveSlugs` exclusion stays per-request (the live set changes independently of disk); only the disk scan is cached.
- **`broadcast-manager.ts`** / **`game-service.ts`** — invalidate the cache **only on live→archived transitions**: `closeConnection()` and `onSite()`.
- **`main.ts`** — warm the cache at startup alongside the pgn/meta caches.

### Why not invalidate on the `tournament-results.json` write?

That file is written on *every game finish* for *live* tournaments — but live tournaments are **filtered out** of the listing. Hooking the write would be both too frequent (a full re-scan per game finish × ~12 broadcasts — re-incurring the exact cost we're caching away) and unnecessary: by the time a tournament is displayed, its broadcast has closed/repointed and its results file is **frozen**. The correct trigger is the live→archived transition, which is what `closeConnection()` / `onSite()` capture.

## Verification

No test runner in this repo — verified via `npm run build` + `npm run lint` (both clean) and a live smoke test against the `16061` feed:

- `GET /` → **200** (no EJS `with(locals)` ReferenceError — `archived` is always passed).
- Previous Broadcasts renders: Berserk Gauntlet (results.json) + PZChessBot / Raphael gauntlets (meta-fallback); PGN-only folders omitted; the currently-live site excluded.
- **Warm cache:** with a temporary scan-trace log, 8 rapid `/` hits triggered **zero** additional disk scans (count held at startup-preload + one `onSite` invalidation). Trace removed before commit.
- `onSite` did not re-fire pathologically on the live feed.