### PR TITLE
feat: rework Results tab with derived records + gauntlet view

### DIFF
--- a/public/css/_responsive.scss
+++ b/public/css/_responsive.scss
@@ -49,6 +49,12 @@
 
   .results-table {
     @include mini-table-mobile-reset;
+
+    // Sticky columns don't make sense in the stacked mobile layout.
+    td.results-name,
+    thead th.results-col-name {
+      position: static;
+    }
   }
 
   .games-table {

--- a/public/css/_results.scss
+++ b/public/css/_results.scss
@@ -3,8 +3,7 @@
 #results-container {
   height: 100%;
   width: 100%;
-  overflow-y: auto;
-  overflow-x: auto;
+  overflow: auto;
   box-sizing: border-box;
   font-size: 0.8rem;
   margin: 0;
@@ -27,6 +26,42 @@
     vertical-align: middle;
   }
 
+  // Engine/Opponent name column sticks on horizontal scroll. The opaque
+  // background occludes h2h columns scrolling underneath (mini-table-reset
+  // forces cells transparent, so this must be set explicitly).
+  td.results-name {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    background: var(--backgroundColor);
+  }
+
+  // The header's name cell is the top-left corner — it must win both axes.
+  thead th.results-col-name {
+    position: sticky;
+    left: 0;
+    z-index: 3;
+  }
+
+  tbody tr:hover td {
+    background: var(--surfaceColorHover);
+  }
+
+  // Keep the sticky name cell opaque on hover: translucent hover over its base.
+  tbody tr:hover td.results-name {
+    background-color: var(--backgroundColor);
+    background-image: linear-gradient(var(--surfaceColorHover), var(--surfaceColorHover));
+  }
+
+  // The gauntlet engine itself — the subject of the gauntlet view — as top row.
+  tbody tr.results-engine-row {
+    border-bottom: 2px solid var(--surfaceColorHover);
+
+    td {
+      font-weight: 700;
+    }
+  }
+
   .results-rank,
   .results-col-rank {
     width: 24px;
@@ -34,13 +69,10 @@
     padding-right: 6px;
     font-weight: 700;
     font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
   }
 
   .results-rank {
-    color: var(--secondaryColor);
-  }
-
-  .results-points {
     color: var(--secondaryColor);
   }
 
@@ -56,13 +88,24 @@
   .results-games {
     text-align: right;
     padding-right: 8px;
+    font-variant-numeric: tabular-nums;
   }
 
   .results-col-points,
-  .results-points {
+  .results-points,
+  .results-col-score,
+  .results-score {
     text-align: right;
     padding-right: 8px;
     font-weight: 700;
+    color: var(--secondaryColor);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .results-col-record,
+  .results-record {
+    text-align: left;
+    padding-right: 12px;
   }
 
   .results-col-h2h,
@@ -82,6 +125,44 @@
 .h2h-empty {
   color: var(--textColor);
   opacity: 0.2;
+}
+
+// Pentanomial pair distribution: five counts, green→red left→right (++ + = − −−).
+.penta-record {
+  display: inline-flex;
+  gap: 5px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+}
+
+.penta-num {
+  min-width: 0.9em;
+  text-align: center;
+
+  &.is-zero {
+    opacity: 0.3;
+    font-weight: 400;
+  }
+}
+
+.penta-4 {
+  color: var(--penta-2);
+} // ++
+.penta-3 {
+  color: var(--penta-15);
+} // +
+.penta-2 {
+  color: var(--penta-1);
+} // =
+.penta-1 {
+  color: var(--penta-05);
+} // −
+.penta-0 {
+  color: var(--penta-0);
+} // −−
+
+.results-gauntlet-group {
+  margin-bottom: 16px;
 }
 
 .results-loading,

--- a/public/css/_variables.scss
+++ b/public/css/_variables.scss
@@ -22,4 +22,11 @@
   --blackArrowColor: #222222dd;
   --kibitzerArrowColor: #114f8add;
   --chatFontWeight: 500;
+  // Pentanomial pair-result spectrum (green → grey → red). Fixed across themes
+  // (JS never overrides these), so they live only in this :root fallback.
+  --penta-2: #4a9d5b; /* ++ (2.0) */
+  --penta-15: #9fc77f; /* + (1.5) */
+  --penta-1: #9a9a9a; /* = (1.0) */
+  --penta-05: #d99a6c; /* − (0.5) */
+  --penta-0: #c45c5c; /* −− (0.0) */
 }

--- a/public/js/components/results/derive.ts
+++ b/public/js/components/results/derive.ts
@@ -1,0 +1,178 @@
+// Pure derivations for the Results crosstable — no DOM, no jQuery.
+//
+// Everything is computed from the `ParsedResults` the server already serves
+// (live `/:port/result-table/json` and archive `/archive/:slug/result-table/json`
+// share this shape), so there is no backend dependency.
+import type { StandingsRow, H2HCell } from '../../../../shared/types';
+
+// Pentanomial pair distribution, low→high pair-score buckets:
+//   [0] −− (0.0)  [1] − (0.5)  [2] = (1.0)  [3] + (1.5)  [4] ++ (2.0)
+export type Penta = [n0: number, n05: number, n1: number, n15: number, n2: number];
+
+export type EngineRecord = {
+  rank: number;
+  name: string;
+  games: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  points: number; // authoritative row.points (not recomputed)
+  scorePct: number; // games === 0 ? 0 : points / games * 100
+  penta: Penta; // aggregated over the row's h2h cells
+};
+
+export type GauntletOpponentRecord = {
+  opponentRank: number;
+  opponentName: string;
+  wins: number;
+  draws: number;
+  losses: number;
+  games: number;
+  points: number;
+  scorePct: number;
+  penta: Penta;
+};
+
+export type GauntletGroup = {
+  engine: EngineRecord;
+  opponents: GauntletOpponentRecord[];
+};
+
+export type GauntletAnalysis = {
+  isGauntlet: boolean;
+  gauntletRanks: number[];
+  groups: GauntletGroup[];
+};
+
+const SCORE: Record<string, number> = { '1': 1, '=': 0.5, '0': 0 };
+
+function isPlayed(cell: H2HCell): boolean {
+  return cell.results !== '**' && cell.results !== '.' && cell.wins + cell.draws + cell.losses > 0;
+}
+
+// Split a matchup's ordered result string into consecutive 2-game pairs and
+// bucket each pair by its combined score. A trailing odd game (an in-progress
+// pair) is excluded from the distribution — its W/L/D still count elsewhere.
+export function cellPenta(cell: H2HCell): Penta {
+  const penta: Penta = [0, 0, 0, 0, 0];
+  const raw = cell.results;
+  if (!raw || raw === '**' || raw === '.') return penta;
+
+  const scores: number[] = [];
+  for (const ch of raw) {
+    if (ch in SCORE) scores.push(SCORE[ch]);
+  }
+
+  for (let i = 0; i + 1 < scores.length; i += 2) {
+    const bucket = Math.round((scores[i] + scores[i + 1]) * 2); // 0..4
+    penta[bucket]++;
+  }
+  return penta;
+}
+
+export function summarizeRow(row: StandingsRow): { wins: number; draws: number; losses: number } {
+  let wins = 0;
+  let draws = 0;
+  let losses = 0;
+  for (const cell of row.h2h) {
+    wins += cell.wins;
+    draws += cell.draws;
+    losses += cell.losses;
+  }
+  return { wins, draws, losses };
+}
+
+// EngineRecord[] aligned to standings order (index i ↔ standings[i]).
+export function deriveRecords(standings: StandingsRow[]): EngineRecord[] {
+  return standings.map((row) => {
+    const { wins, draws, losses } = summarizeRow(row);
+    const penta: Penta = [0, 0, 0, 0, 0];
+    for (const cell of row.h2h) {
+      const p = cellPenta(cell);
+      for (let i = 0; i < 5; i++) penta[i] += p[i];
+    }
+    return {
+      rank: row.rank,
+      name: row.name,
+      games: row.games,
+      wins,
+      draws,
+      losses,
+      points: row.points,
+      scorePct: row.games === 0 ? 0 : (row.points / row.games) * 100,
+      penta,
+    };
+  });
+}
+
+function playedCount(row: StandingsRow): number {
+  let n = 0;
+  for (const cell of row.h2h) {
+    if (isPlayed(cell)) n++;
+  }
+  return n;
+}
+
+function median(nums: number[]): number {
+  if (!nums.length) return 0;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+// For one gauntlet engine, expand its h2h row into per-opponent records.
+export function buildGauntletGroup(
+  engineIndex: number,
+  standings: StandingsRow[],
+  records: EngineRecord[],
+): GauntletGroup {
+  const row = standings[engineIndex];
+  const opponents: GauntletOpponentRecord[] = [];
+
+  row.h2h.forEach((cell, j) => {
+    if (j === engineIndex || !standings[j] || !isPlayed(cell)) return;
+    const games = cell.wins + cell.draws + cell.losses;
+    const points = cell.wins + 0.5 * cell.draws;
+    opponents.push({
+      opponentRank: standings[j].rank,
+      opponentName: standings[j].name,
+      wins: cell.wins,
+      draws: cell.draws,
+      losses: cell.losses,
+      games,
+      points,
+      scorePct: games === 0 ? 0 : (points / games) * 100,
+      penta: cellPenta(cell),
+    });
+  });
+
+  opponents.sort((a, b) => a.opponentRank - b.opponentRank);
+  return { engine: records[engineIndex], opponents };
+}
+
+// Conservative gauntlet detection: a few engines that played nearly everyone,
+// while the rest played only the gauntlet engine(s). False negatives (showing
+// the matrix) are harmless; false positives (hiding it) are not.
+export function detectGauntlet(standings: StandingsRow[], records: EngineRecord[]): GauntletAnalysis {
+  const empty: GauntletAnalysis = { isGauntlet: false, gauntletRanks: [], groups: [] };
+  const N = standings.length;
+  if (N < 3) return empty;
+
+  const played = standings.map(playedCount);
+  const threshold = Math.max(3, 2.5 * Math.max(1, median(played)));
+
+  const runnerIdx: number[] = [];
+  played.forEach((p, i) => {
+    if (p >= threshold) runnerIdx.push(i);
+  });
+
+  const minorityCap = Math.max(1, Math.floor(N / 3));
+  const ok = runnerIdx.length >= 1 && runnerIdx.length < N && runnerIdx.length <= minorityCap;
+  if (!ok) return empty;
+
+  return {
+    isGauntlet: true,
+    gauntletRanks: runnerIdx.map((i) => standings[i].rank),
+    groups: runnerIdx.map((i) => buildGauntletGroup(i, standings, records)),
+  };
+}

--- a/public/js/components/results/index.ts
+++ b/public/js/components/results/index.ts
@@ -1,28 +1,53 @@
-// public/js/components/results/index.js
+// public/js/components/results/index.ts
 import $ from 'jquery';
 import type { H2HCell, StandingsRow } from '../../../../shared/types';
 import { on } from '../../events/index';
 import { apiBase } from '../../utils/url';
+import { deriveRecords, detectGauntlet } from './derive';
+import type { EngineRecord, GauntletGroup, Penta } from './derive';
 
-function renderH2HCell(cell: H2HCell, isSelf: boolean) {
+type WLD = { wins: number; draws: number; losses: number };
+
+// Glyphs by pentanomial bucket index: 0=−− 1=− 2== 3=+ 4=++.
+const PENTA_GLYPHS = ['−−', '−', '=', '+', '++'];
+
+function fmtPts(points: number): string {
+  return points % 1 === 0 ? `${points}.0` : `${points}`;
+}
+
+function fmtScore(games: number, scorePct: number): string {
+  return games === 0 ? '–' : `${scorePct.toFixed(1)}%`;
+}
+
+// Pentanomial pair distribution as five colored counts, green→red left→right
+// (++ + = − −−). Exact glyph breakdown + W-L-D in the tooltip.
+function pentaRecord(penta: Penta, wld?: WLD): JQuery<HTMLElement> {
+  const $wrap = $('<span>').addClass('penta-record');
+  for (let i = 4; i >= 0; i--) {
+    $('<span>')
+      .addClass(`penta-num penta-${i}`)
+      .toggleClass('is-zero', penta[i] === 0)
+      .text(penta[i])
+      .appendTo($wrap);
+  }
+
+  const total = penta.reduce((a, b) => a + b, 0);
+  const breakdown = [4, 3, 2, 1, 0].map((i) => `${PENTA_GLYPHS[i]}${penta[i]}`).join('  ');
+  let title = `${breakdown} · ${total} pair${total === 1 ? '' : 's'}`;
+  if (wld) title += ` · W-L-D ${wld.wins}-${wld.losses}-${wld.draws}`;
+  $wrap.attr('title', title).attr('aria-label', title);
+  return $wrap;
+}
+
+function renderH2HCell(cell: H2HCell): JQuery<HTMLElement> {
   const $td = $('<td>').addClass('results-h2h-cell');
-
-  if (isSelf) {
-    return $td.addClass('h2h-self');
-  }
-
-  if (!cell.results || cell.results === '.') {
-    return $td.addClass('h2h-empty').text('\u00b7');
-  }
-
+  if (cell.results === '**') return $td.addClass('h2h-self');
+  if (!cell.results || cell.results === '.') return $td.addClass('h2h-empty').text('·');
   return $td.text(cell.results);
 }
 
-function renderStandings(standings: StandingsRow[]) {
-  if (!standings.length) {
-    return $('<p>').addClass('results-empty').text('No standings data available.');
-  }
-
+// Round-robin / non-gauntlet: the enhanced crosstable matrix.
+function renderMatrix(records: EngineRecord[], standings: StandingsRow[]): JQuery<HTMLElement> {
   const $wrapper = $('<div>').addClass('results-table-wrapper');
   const $table = $('<table>').addClass('results-table');
 
@@ -31,31 +56,24 @@ function renderStandings(standings: StandingsRow[]) {
   $hr.append($('<th>').addClass('results-col-rank').text('#'));
   $hr.append($('<th>').addClass('results-col-name').text('Engine'));
   $hr.append($('<th>').addClass('results-col-games').text('G'));
+  $hr.append($('<th>').addClass('results-col-record').text('Record'));
   $hr.append($('<th>').addClass('results-col-points').text('Pts'));
-
-  standings.forEach((row: StandingsRow) => {
-    $hr.append($('<th>').addClass('results-col-h2h').text(row.rank));
-  });
-
+  $hr.append($('<th>').addClass('results-col-score').text('Score'));
+  records.forEach((r) => $hr.append($('<th>').addClass('results-col-h2h').text(r.rank)));
   $thead.append($hr);
   $table.append($thead);
 
   const $tbody = $('<tbody>');
-  standings.forEach((row: StandingsRow) => {
+  records.forEach((rec, i) => {
+    const row = standings[i];
     const $tr = $('<tr>');
-    $tr.append($('<td>').addClass('results-rank').text(row.rank));
-    $tr.append($('<td>').addClass('results-name').attr('title', row.name).text(row.name));
-    $tr.append($('<td>').addClass('results-games').text(row.games));
-    $tr.append(
-      $('<td>')
-        .addClass('results-points')
-        .text(row.points % 1 === 0 ? `${row.points}.0` : row.points),
-    );
-
-    row.h2h.forEach((cell: H2HCell) => {
-      $tr.append(renderH2HCell(cell, cell.results === '**'));
-    });
-
+    $tr.append($('<td>').addClass('results-rank').text(rec.rank));
+    $tr.append($('<td>').addClass('results-name').attr('title', rec.name).text(rec.name));
+    $tr.append($('<td>').addClass('results-games').text(rec.games));
+    $tr.append($('<td>').addClass('results-record').append(pentaRecord(rec.penta, rec)));
+    $tr.append($('<td>').addClass('results-points').text(fmtPts(rec.points)));
+    $tr.append($('<td>').addClass('results-score').text(fmtScore(rec.games, rec.scorePct)));
+    row.h2h.forEach((cell) => $tr.append(renderH2HCell(cell)));
     $tbody.append($tr);
   });
 
@@ -64,7 +82,50 @@ function renderStandings(standings: StandingsRow[]) {
   return $wrapper;
 }
 
-function fetchAndRender() {
+// Gauntlet: the gauntlet engine as the top row, then its record vs each opponent.
+function renderGauntletGroup(group: GauntletGroup): JQuery<HTMLElement> {
+  const $group = $('<div>').addClass('results-gauntlet-group');
+  const eng = group.engine;
+
+  const $table = $('<table>').addClass('results-table');
+  const $thead = $('<thead>');
+  const $hr = $('<tr>');
+  $hr.append($('<th>').addClass('results-col-name').text('Engine'));
+  $hr.append($('<th>').addClass('results-col-games').text('Pairs'));
+  $hr.append($('<th>').addClass('results-col-record').text('Record'));
+  $hr.append($('<th>').addClass('results-col-points').text('Pts'));
+  $hr.append($('<th>').addClass('results-col-score').text('Score'));
+  $thead.append($hr);
+  $table.append($thead);
+
+  const $tbody = $('<tbody>');
+
+  const engPairs = eng.penta.reduce((a, b) => a + b, 0);
+  const $engRow = $('<tr>').addClass('results-engine-row');
+  $engRow.append($('<td>').addClass('results-name').attr('title', eng.name).text(eng.name));
+  $engRow.append($('<td>').addClass('results-games').text(engPairs));
+  $engRow.append($('<td>').addClass('results-record').append(pentaRecord(eng.penta, eng)));
+  $engRow.append($('<td>').addClass('results-points').text(fmtPts(eng.points)));
+  $engRow.append($('<td>').addClass('results-score').text(fmtScore(eng.games, eng.scorePct)));
+  $tbody.append($engRow);
+
+  group.opponents.forEach((o) => {
+    const pairs = o.penta.reduce((a, b) => a + b, 0);
+    const $tr = $('<tr>');
+    $tr.append($('<td>').addClass('results-name').attr('title', o.opponentName).text(o.opponentName));
+    $tr.append($('<td>').addClass('results-games').text(pairs));
+    $tr.append($('<td>').addClass('results-record').append(pentaRecord(o.penta, o)));
+    $tr.append($('<td>').addClass('results-points').text(fmtPts(o.points)));
+    $tr.append($('<td>').addClass('results-score').text(fmtScore(o.games, o.scorePct)));
+    $tbody.append($tr);
+  });
+
+  $table.append($tbody);
+  $group.append($table);
+  return $group;
+}
+
+function fetchAndRender(): void {
   const $container = $('#results-container');
   $container.html('<p class="results-loading">Loading results...</p>');
 
@@ -73,10 +134,23 @@ function fetchAndRender() {
     method: 'GET',
     dataType: 'json',
   })
-    .done((data) => {
+    .done((data: { standings?: StandingsRow[] }) => {
+      const standings = data.standings || [];
       $container.empty();
 
-      $container.append(renderStandings(data.standings || []));
+      if (!standings.length) {
+        $container.append($('<p>').addClass('results-empty').text('No standings data available.'));
+        return;
+      }
+
+      const records = deriveRecords(standings);
+      const analysis = detectGauntlet(standings, records);
+
+      if (analysis.isGauntlet) {
+        analysis.groups.forEach((g) => $container.append(renderGauntletGroup(g)));
+      } else {
+        $container.append(renderMatrix(records, standings));
+      }
     })
     .fail(() => {
       $container.html('<p class="results-error">No results available.</p>');


### PR DESCRIPTION
## Summary

Reworks the **Results** tab — *"the heart of what the audience reads"* — to surface the analytics already implicit in the CT crosstable instead of rendering the raw `=`/`1`/`0`/`.` matrix verbatim. **Frontend-only**: everything is derived from the `ParsedResults` already served at `/:port/result-table/json` (and the identical `/archive/:slug/result-table/json`), so live and archived tournaments share one code path with no parser/persisted-shape changes.

Implements idea **B1** from the improvement-ideas backlog.

## What changed

- **`results/derive.ts`** (new, pure helpers): per-engine **W-L-D**, **score %**, and a **pentanomial pair distribution** reconstructed by splitting each head-to-head cell's ordered result string into back-to-back game pairs (`++`/`+`/`=`/`−`/`−−`). Plus a conservative **gauntlet detector** (engines that played far more opponents than the median; round-robins never trip it).
- **Gauntlet view**: gauntlet broadcasts render a dedicated table — the **gauntlet engine as the top row**, then its record vs each opponent — replacing the sparse, mostly-`.` matrix.
- **Matrix view**: round-robins render the enhanced crosstable (`# · Engine · G · Record · Pts · Score · h2h…`).
- **Record** is shown as **five colored counts** (`++ + = − −−`), green→red left→right, zeros dimmed.
- **Sticky engine-name column** on horizontal scroll + row hover highlight.
- Five fixed pentanomial spectrum colors added to `:root` in `_variables.scss` (uniform across themes).

## Verification

- Frontend `tsc` (tsconfig.frontend), ESLint, and Prettier all clean. (Backend `tsc` has a pre-existing duplicate-`@types/node` conflict in this environment, unrelated to this change.)
- Live Playwright walkthrough against two real broadcasts:
  - **Gauntlet** (Berserk Gauntlet): auto-opens the gauntlet view; Berserk as top row with overall `0 8 86 5 0` record, per-opponent breakdown, score % correct.
  - **Round-robin** (124th Amateur): matrix view; record numbers gradient green (REVOLVER 79.5%) → red (SOOMI 27.9%); sticky engine column holds on horizontal scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)