### PR TITLE
feat: show engine names, evals, and clocks in focus mode

### DIFF
--- a/public/css/_focus.scss
+++ b/public/css/_focus.scss
@@ -1,4 +1,14 @@
+// Focus-info strips are hidden outside of focus mode.
+// Using a class selector (.focus-info, specificity=10) so that the body.focus-mode .focus-info
+// rule (specificity=21) can override it without needing !important.
+.focus-info {
+  display: none;
+}
+
 body.focus-mode {
+  --focus-strip-h: 2.75rem;
+  --focus-board-size: min(100vw, calc(100vh - 2 * var(--focus-strip-h)));
+
   background: #1a1a1a;
 
   .site-header,
@@ -17,15 +27,74 @@ body.focus-mode {
 
   .main-layout {
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
+    width: 100vw;
     height: 100vh;
     padding: 0;
     gap: 0;
   }
 
   #board-container {
-    width: min(100vw, 100vh);
-    height: min(100vw, 100vh);
+    width: var(--focus-board-size);
+    height: var(--focus-board-size);
+  }
+
+  .focus-info {
+    box-sizing: border-box;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: var(--focus-board-size);
+    height: var(--focus-strip-h);
+    padding: 0 0.5rem;
+    color: rgba(255, 255, 255, 0.9);
+    font-size: 1rem;
+
+    .focus-name {
+      font-weight: 600;
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      margin-right: 1rem;
+    }
+
+    .focus-stats {
+      display: flex;
+      align-items: center;
+      gap: 1.25rem;
+      flex-shrink: 0;
+      font-variant-numeric: tabular-nums;
+      font-family: monospace;
+
+      .focus-score {
+        min-width: 3.5rem;
+        text-align: right;
+        color: rgba(255, 255, 255, 0.75);
+      }
+
+      .focus-time {
+        min-width: 3.5rem;
+        text-align: right;
+        font-weight: 600;
+      }
+    }
+  }
+}
+
+@media (max-width: 767px) {
+  body.focus-mode {
+    --focus-strip-h: 2.25rem;
+
+    .focus-info {
+      font-size: 0.8rem;
+      padding: 0 0.35rem;
+
+      .focus-stats {
+        gap: 0.75rem;
+      }
+    }
   }
 }

--- a/public/js/components/focus/index.ts
+++ b/public/js/components/focus/index.ts
@@ -2,8 +2,131 @@
 import $ from 'jquery';
 import { resize as resizeBoard } from '../board/index';
 import { chatHeight } from '../board/resize';
+import { on, off } from '../../events/index';
+import type { GameEventData, NavPosition } from '../../events/index';
+import type { SerializedGame } from '../../../../shared/types';
+import { colorName } from '../../../../shared/colors';
+import { formatScore } from '../game/player-info';
+import { msToString } from '../game/timers';
+import { isReplayMode } from '../replay/index';
 
 let active = false;
+let flipped = false;
+let live = true;
+let navIndex = 0;
+let lastGame: SerializedGame | null = null;
+const focusClockIntervals = new Map<string, ReturnType<typeof setInterval>>();
+
+function topColor(): 'white' | 'black' {
+  return flipped ? 'white' : 'black';
+}
+
+function bottomColor(): 'white' | 'black' {
+  return flipped ? 'black' : 'white';
+}
+
+function clearFocusClocks() {
+  focusClockIntervals.forEach((interval) => clearInterval(interval));
+  focusClockIntervals.clear();
+}
+
+function renderStrip(color: 'white' | 'black', game: SerializedGame) {
+  const isTop = color === topColor();
+  const $strip = $(isTop ? '#focus-info-top' : '#focus-info-bottom');
+
+  // Name
+  $strip.find('.focus-name').text(game[color].name);
+
+  // Eval — mirrors the logic in player-info.ts update()
+  const liveColor = colorName(game.liveData.color);
+  let scoreText = '--';
+
+  if (live) {
+    if (color === liveColor) {
+      // Thinking side: use the live engine evaluation (white-perspective; formatScore negates for black)
+      scoreText = formatScore(game.liveData.score, color);
+    } else {
+      // Non-thinking side: show the eval from the most recent completed move
+      const moves = game.moves || [];
+      const lastMeta = moves.length ? moves[moves.length - 1] : null;
+      if (lastMeta && lastMeta.depth !== null && lastMeta.score != null) {
+        scoreText = formatScore(lastMeta.score, color);
+      }
+    }
+  } else {
+    // Historical navigation: search backward for the most recent eval for this color
+    const colorChar = color === 'white' ? 'w' : 'b';
+    const moves = game.moves || [];
+    for (let i = Math.min(navIndex - 1, moves.length - 1); i >= 0; i--) {
+      const move = moves[i];
+      if (move.color === colorChar && move.score != null) {
+        scoreText = formatScore(move.score, color);
+        break;
+      }
+    }
+  }
+
+  $strip.find('.focus-score').text(scoreText);
+}
+
+function startFocusClock(color: 'white' | 'black', game: SerializedGame) {
+  const isTop = color === topColor();
+  const $time = $(isTop ? '#focus-info-top .focus-time' : '#focus-info-bottom .focus-time');
+
+  const { clockTime, startTime } = game[color];
+
+  if (!live || isReplayMode() || clockTime === 0) {
+    $time.text('--:--');
+    return;
+  }
+
+  const sideToMove = game.stm === 'w' ? 'white' : 'black';
+  if (color === sideToMove) {
+    // Ticking clock for the side-to-move
+    const tick = () => {
+      const remaining = Math.max(0, clockTime - (Date.now() - startTime));
+      $time.text(msToString(remaining));
+    };
+    tick();
+    focusClockIntervals.set(color, setInterval(tick, 1000));
+  } else {
+    // Static remaining time for the waiting side
+    $time.text(msToString(clockTime));
+  }
+}
+
+function render(game: SerializedGame) {
+  if (!active) return;
+  clearFocusClocks();
+  renderStrip(topColor(), game);
+  renderStrip(bottomColor(), game);
+  startFocusClock(topColor(), game);
+  startFocusClock(bottomColor(), game);
+}
+
+function handleGameState(data: GameEventData) {
+  live = true;
+  lastGame = data.game;
+  render(data.game);
+}
+
+function handleGameUpdate(data: GameEventData) {
+  if (isReplayMode()) return;
+  live = true;
+  lastGame = data.game;
+  render(data.game);
+}
+
+function handleNavPosition({ isLive, index }: NavPosition) {
+  live = isLive;
+  navIndex = index;
+  if (lastGame) render(lastGame);
+}
+
+function handleFlip({ flipped: f }: { flipped: boolean }) {
+  flipped = f;
+  if (lastGame) render(lastGame);
+}
 
 function toggle() {
   active = !active;
@@ -13,7 +136,10 @@ function toggle() {
   setTimeout(() => {
     resizeBoard();
     if (!active) {
+      clearFocusClocks();
       $('#chat-area').height(chatHeight());
+    } else if (lastGame) {
+      render(lastGame);
     }
   }, 50);
 }
@@ -27,9 +153,19 @@ function handleKeyDown(e: JQuery.KeyDownEvent) {
 export function init() {
   $('#focus-toggle').on('click', toggle);
   $(document).on('keydown', handleKeyDown);
+
+  on('game:state', handleGameState);
+  on('game:update', handleGameUpdate);
+  on('nav:position', handleNavPosition);
+  on('board:flip', handleFlip);
 }
 
 export function destroy() {
   $('#focus-toggle').off('click');
   $(document).off('keydown', handleKeyDown);
+  clearFocusClocks();
+  off('game:state', handleGameState);
+  off('game:update', handleGameUpdate);
+  off('nav:position', handleNavPosition);
+  off('board:flip', handleFlip);
 }

--- a/public/js/components/game/player-info.ts
+++ b/public/js/components/game/player-info.ts
@@ -12,7 +12,7 @@ function updateElText(el: JQuery, val: string) {
 
 const MATE_SCORE_THRESHOLD = 100000;
 
-function formatScore(score: number, color: string) {
+export function formatScore(score: number, color: string) {
   const s = color === 'black' ? score * -1 : score;
 
   if (s > MATE_SCORE_THRESHOLD) {

--- a/public/js/components/game/timers.ts
+++ b/public/js/components/game/timers.ts
@@ -5,7 +5,7 @@ import type { GameEventData } from '../../events/index';
 
 const timerIntervals = new Map<string, ReturnType<typeof setInterval>>();
 
-function msToString(ms: number) {
+export function msToString(ms: number) {
   const s = Math.floor((ms / 1000) % 60);
   const m = Math.floor(ms / 1000 / 60);
   return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -11,6 +11,10 @@
     <%- include('../partials/header', { siteName: archive ? site : game.site, showFocus: true, showFlip: true }) %>
     <div class="container">
       <div class="main-layout">
+        <div id="focus-info-top" class="focus-info" aria-hidden="true">
+          <span class="focus-name"></span>
+          <span class="focus-stats"><span class="focus-score"></span><span class="focus-time"></span></span>
+        </div>
         <div id="board-container">
           <canvas id="arrow-board" height="2400" width="2400" aria-hidden="true"></canvas>
           <div id="board" aria-hidden="true"></div>
@@ -29,6 +33,10 @@
           <%- include('../partials/info-card', { color: 'black' }) %>
           <%- include('../partials/chat', { archive, port }) %>
           <%- include('../partials/info-card', { color: 'white' }) %>
+        </div>
+        <div id="focus-info-bottom" class="focus-info" aria-hidden="true">
+          <span class="focus-name"></span>
+          <span class="focus-stats"><span class="focus-score"></span><span class="focus-time"></span></span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Focus mode previously showed only the bare board with no context — no player names, no evaluations, no clocks. This adds two compact player strips (above and below the board) that display each engine's essential info without leaving focus mode.

- Engine name (left), numeric eval and remaining clock (right), Lichess-style
- Board shrinks to make room for the strips (`min(100vw, 100vh − 2×strip-height)`) — nothing overlaps the pieces
- Active clock ticks live via its own 1-second interval (works even though the normal info-cards are hidden)
- Board flip swaps which engine is on top/bottom
- Replay/archive pages show `--:--` for clocks, names and evals still render
- Mobile (≤767px): smaller font and tighter padding, full names visible

## Changes

| File | What changed |
|------|-------------|
| `views/pages/index.ejs` | Two strip elements (`#focus-info-top` / `#focus-info-bottom`) added as `.main-layout` siblings |
| `public/css/_focus.scss` | Column flex layout, `--focus-board-size` sizing, strip styles, responsive block |
| `public/js/components/focus/index.ts` | Self-contained renderer: event bus subscriptions, clock intervals, flip/nav/replay handling |
| `public/js/components/game/player-info.ts` | Exported `formatScore` for reuse |
| `public/js/components/game/timers.ts` | Exported `msToString` for reuse |

## Test plan

- [x] Live broadcast: names, evals, and ticking clock verified with Playwright against live game
- [x] Eval values match hidden info-cards
- [x] Board flip swaps strip assignments correctly
- [x] Escape exits focus, normal layout restores cleanly
- [x] Archive/replay: names render, clocks show `--:--`, no JS errors
- [x] Mobile 390×844: full names visible, no clipping
- [x] `npm run build` (webpack + tsc) passes clean