### PR TITLE
feat: recent-connections autocomplete for the admin connection input

### DIFF
--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -10,6 +10,7 @@ Project-wide pitfalls and constraints that don't fit a single subsystem.
 ## Configuration
 
 - **Connections format**: Each `connections` entry is either a bare `"host:port"` string (default mode) or an object `{ "connection": "host:port", "ephemeral": true }`. Both forms are accepted on read; the admin "Add new" form writes a bare string unless the "Ephemeral local port" checkbox is set.
+- **Connection history**: Optional `connectionHistory` array of bare `"host:port"` strings, newest first, capped at 50. Seeded from `connections` at boot and prepended on every add; **not** pruned when a connection is closed — it backs the `<datalist>` autocomplete on the admin "Add new" form, whose whole purpose is remembering closed broadcasts. Absent in older configs (treated as empty).
 - **Kibitzer config**: Optional. Each entry has an `id` (auto-assigned if missing), `type` (`"local"` or `"ssh"`), `priority` (higher = assigned to more-viewed broadcasts), and type-specific fields. Both types accept optional `threads` (default 1) and `hash` (default 256).
 - **Webhook config**: Optional. Each entry has an `id` (auto-assigned if missing), `type` (`"discord"` only), `url`, optional `name`, optional `ports` array (empty = all broadcasts), and optional `events` array of `"game-started"` / `"game-finished"` (empty = both).
 

--- a/src/broadcast-manager.ts
+++ b/src/broadcast-manager.ts
@@ -30,6 +30,8 @@ export function getWebhookManager(): WebhookManager | null {
 
 export async function connect(): Promise<void> {
   const connections = await configStore.getConnections();
+  // Seed the admin autocomplete: boot connections never pass through addConnection().
+  await configStore.recordConnectionHistory(connections.map((c) => c.connection));
 
   for (const { connection, ephemeral } of connections) {
     const [url, port] = connection.split(':');

--- a/src/config/config-store.ts
+++ b/src/config/config-store.ts
@@ -13,12 +13,20 @@ export type ConnectionEntry = string | ConnectionConfig;
 
 export interface AppConfig {
   connections: ConnectionEntry[];
+  connectionHistory?: string[];
   kibitzers?: KibitzerConfig[];
   webhooks?: WebhookConfig[];
 }
 
+const HISTORY_LIMIT = 50;
+
 function normalizeConnection(entry: ConnectionEntry): ConnectionConfig {
   return typeof entry === 'string' ? { connection: entry, ephemeral: false } : { ephemeral: false, ...entry };
+}
+
+/** Newest-first LRU merge: `added` moves to the front, dupes drop, capped at HISTORY_LIMIT. */
+function mergeHistory(history: string[], added: string[]): string[] {
+  return [...added, ...history.filter((c) => !added.includes(c))].slice(0, HISTORY_LIMIT);
 }
 
 export class ConfigStore {
@@ -50,6 +58,19 @@ export class ConfigStore {
     // ephemeral is set. Reads tolerate both forms via normalizeConnection().
     const entry: ConnectionEntry = ephemeral ? { connection, ephemeral: true } : connection;
     config.connections = [...existing, entry];
+    config.connectionHistory = mergeHistory(config.connectionHistory ?? [], [connection]);
+    await this.save(config);
+  }
+
+  // History deliberately outlives removeConnection() — remembering closed broadcasts is the point.
+  async getConnectionHistory(): Promise<string[]> {
+    const config = await this.load();
+    return config.connectionHistory ?? [];
+  }
+
+  async recordConnectionHistory(connections: string[]): Promise<void> {
+    const config = await this.load();
+    config.connectionHistory = mergeHistory(config.connectionHistory ?? [], connections);
     await this.save(config);
   }
 

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -18,12 +18,16 @@ router.use(
   }),
 );
 
-router.get('/', (_: Request, res: Response) => {
+router.get('/', async (_: Request, res: Response) => {
   const kibitzerManager = getKibitzerManager();
+  // Already-live connections would only 400 with "Port already in use!" — keep them out of the picker.
+  const active = new Set([...broadcasts.values()].map((b) => b.connection));
+
   res.render('pages/admin', {
     broadcasts: broadcasts.values(),
     kibitzers: kibitzerManager?.getStatus() ?? [],
     webhooks: getWebhookManager()?.getStatus() ?? [],
+    connectionHistory: (await configStore.getConnectionHistory()).filter((c) => !active.has(c)),
   });
 });
 

--- a/views/pages/admin.ejs
+++ b/views/pages/admin.ejs
@@ -43,7 +43,19 @@
         <form id="add-new" class="admin-form admin-form--inline">
           <div class="field">
             <label for="connection">Connection</label>
-            <input id="connection" name="connection" required placeholder="GrahamCCRL.dyndns.org:16000" />
+            <input
+              id="connection"
+              name="connection"
+              required
+              placeholder="GrahamCCRL.dyndns.org:16000"
+              list="connection-history"
+              autocomplete="off"
+            />
+            <datalist id="connection-history">
+              <% for (const c of connectionHistory) { %>
+              <option value="<%= c %>"></option>
+              <% } %>
+            </datalist>
           </div>
           <div class="field">
             <label class="webhook-event-option">


### PR DESCRIPTION
## Summary

Adds a `<datalist>`-based autocomplete dropdown to the admin panel connection input, backed by a `connectionHistory` array persisted in `config/config.json`. This gives admins a browser-native dropdown of recently-used broadcasts without relying on the browsers built-in form autocomplete.

## Changes

| File | Change |
|------|--------|
| `src/config/config-store.ts` | Added `connectionHistory` field to `AppConfig`, plus `getConnectionHistory()`, `recordConnectionHistory()`, and history-tracking in `addConnection()` |
| `src/broadcast-manager.ts` | Seed history at boot from existing connections so the datalist is immediately useful on existing deployments |
| `src/routes/admin.ts` | Pass `connectionHistory` (filtered to remove already-live connections) to the admin template |
| `views/pages/admin.ejs` | Add `list="connection-history"` + `autocomplete="off"` to the input, and a `<datalist>` of options |
| `docs/gotchas.md` | Document the new `connectionHistory` config field |

## How it works

1. When any connection is added via the admin panel or config, its prepended to `connectionHistory` (deduped, newest first, capped at 50)
2. On server boot, the existing `connections` array seeds the history so existing deployments get immediate value
3. The admin page renders the history as a `<datalist>` — the browser handles filtering as the user types
4. Closed connections remain in history so they can be easily re-added
5. Active connections are filtered out of the dropdown (adding them would throw "Port already in use!")

## Verification

- `npm run build` — passes (webpack + tsc)
- ESLint — passes (exit 0)
- Prettier — passes (no changes)
- Config-store logic — manually tested with scratch configs (legacy config, boot seeding, add/close cycles)
- Template rendering — manually tested with EJS render

Note: The server segfaults on boot in this environment due to a pre-existing `prom-client` + Node v22.22.2 incompatibility (confirmed on unmodified main). This change does not introduce the issue.