### PR TITLE
feat: add fuzzy player filter to games tab

### DIFF
--- a/public/css/_games.scss
+++ b/public/css/_games.scss
@@ -1,5 +1,16 @@
 @use 'mixins' as *;
 
+.games-filter {
+  padding: 8px 10px;
+  margin: 0;
+
+  #games-filter-input {
+    width: 100%;
+    box-sizing: border-box;
+    font-size: 0.8rem;
+  }
+}
+
 #games-container {
   height: 100%;
   width: 100%;

--- a/public/css/_games.scss
+++ b/public/css/_games.scss
@@ -1,12 +1,13 @@
 @use 'mixins' as *;
 
 .games-filter {
-  padding: 8px 10px;
+  padding: 0 0 8px;
   margin: 0;
 
   #games-filter-input {
     width: 100%;
     box-sizing: border-box;
+    margin: 0;
     font-size: 0.8rem;
   }
 }

--- a/public/js/components/games/index.ts
+++ b/public/js/components/games/index.ts
@@ -9,9 +9,45 @@ const DOWNLOAD_ICON =
 const PLAY_ICON =
   '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5,3 19,12 5,21"></polygon></svg>';
 
+let allGames: GameRecord[] = [];
+
+function normalizeForMatch(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+// Fuzzy match: case-insensitive, tolerant of gaps/typos (subsequence) and of
+// out-of-order query characters (all query chars present in the name).
+function fuzzyMatches(query: string, name: string): boolean {
+  const q = normalizeForMatch(query);
+  const n = normalizeForMatch(name);
+  if (!q) return true;
+  if (n.length < q.length) return false;
+
+  let qi = 0;
+  for (let ni = 0; ni < n.length && qi < q.length; ni++) {
+    if (n.charCodeAt(ni) === q.charCodeAt(qi)) qi++;
+  }
+  if (qi === q.length) return true;
+
+  const remaining = new Map<string, number>();
+  for (const c of n) remaining.set(c, (remaining.get(c) ?? 0) + 1);
+  for (const c of q) {
+    const left = (remaining.get(c) ?? 0) - 1;
+    if (left < 0) return false;
+    remaining.set(c, left);
+  }
+  return true;
+}
+
+function matchesQuery(game: GameRecord, query: string): boolean {
+  return fuzzyMatches(query, game.white) || fuzzyMatches(query, game.black);
+}
+
 function renderGames(games: GameRecord[]) {
   if (!games.length) {
-    return $('<p>').addClass('games-empty').text('No games data available.');
+    return $('<p>')
+      .addClass('games-empty')
+      .text(allGames.length ? 'No games match your filter.' : 'No games data available.');
   }
 
   const $table = $('<table>').addClass('games-table');
@@ -73,6 +109,14 @@ function loadReplay(gameNumber: number) {
     });
 }
 
+function applyFilter() {
+  const query = String($('#games-filter-input').val() ?? '');
+  const filtered = query ? allGames.filter((g) => matchesQuery(g, query)) : allGames;
+  const $container = $('#games-container');
+  $container.empty();
+  $container.append(renderGames(filtered));
+}
+
 function fetchAndRender() {
   const $container = $('#games-container');
   $container.html('<p class="games-loading">Loading games...</p>');
@@ -83,8 +127,8 @@ function fetchAndRender() {
     dataType: 'json',
   })
     .done((data: GameRecord[]) => {
-      $container.empty();
-      $container.append(renderGames(data));
+      allGames = data;
+      applyFilter();
     })
     .fail(() => {
       $container.html('<p class="games-error">No games available.</p>');
@@ -107,6 +151,8 @@ function autoLoadLatest() {
 }
 
 export function init() {
+  $('#games-filter-input').on('input', applyFilter);
+
   on('tab:change', ({ tab }) => {
     if (tab === 'games') fetchAndRender();
   });

--- a/views/partials/chat.ejs
+++ b/views/partials/chat.ejs
@@ -60,6 +60,9 @@
   </div>
 
   <div id="games-tab-panel" class="tab-panel">
+    <div class="games-filter">
+      <input id="games-filter-input" type="search" placeholder="Filter by player..." autocomplete="off" />
+    </div>
     <div class="card fluid" id="games-container"></div>
   </div>
 


### PR DESCRIPTION
## Summary
Adds a client-side fuzzy filter to the **Games** tab so users can type to narrow a large (300+) games list down by player name.

- New search input at the top of the Games tab panel (`views/partials/chat.ejs`)
- Client-side filtering in `public/js/components/games/index.ts` — narrows rows where **White** or **Black** matches the query
- Case-insensitive, tolerant of typos and out-of-order characters
- Empty/cleared query restores the full list
- Styling in `public/css/_games.scss`
- Works in both live and archive modes; no API/backend changes

## Files changed
- `views/partials/chat.ejs`
- `public/js/components/games/index.ts`
- `public/css/_games.scss`

## Verification
- `npm run build` — passes (webpack frontend + TypeScript backend)
- `npm run lint` — passes