### PR TITLE
feat(games): add decisive-only filter checkbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ build/
 .node-version
 .env
 pgns/
+
+# QA / browser automation artifacts
+.playwright-mcp/
+dogfood-output/

--- a/public/css/_games.scss
+++ b/public/css/_games.scss
@@ -1,14 +1,32 @@
 @use 'mixins' as *;
 
 .games-filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   padding: 0 0 8px;
   margin: 0;
 
   #games-filter-input {
-    width: 100%;
+    flex: 1;
+    min-width: 0;
     box-sizing: border-box;
     margin: 0;
     font-size: 0.8rem;
+  }
+
+  .games-filter-decisive {
+    flex: none;
+    white-space: nowrap;
+    font-size: 0.75rem;
+    margin: 0;
+    cursor: pointer;
+
+    input[type='checkbox'] {
+      margin: 0 4px 0 0;
+      vertical-align: middle;
+      cursor: pointer;
+    }
   }
 }
 

--- a/public/js/components/games/index.ts
+++ b/public/js/components/games/index.ts
@@ -43,6 +43,10 @@ function matchesQuery(game: GameRecord, query: string): boolean {
   return fuzzyMatches(query, game.white) || fuzzyMatches(query, game.black);
 }
 
+function isDecisive(result: string): boolean {
+  return result === '1-0' || result === '0-1';
+}
+
 function renderGames(games: GameRecord[]) {
   if (!games.length) {
     return $('<p>')
@@ -111,7 +115,14 @@ function loadReplay(gameNumber: number) {
 
 function applyFilter() {
   const query = String($('#games-filter-input').val() ?? '');
-  const filtered = query ? allGames.filter((g) => matchesQuery(g, query)) : allGames;
+  const decisiveOnly = ($('#games-filter-decisive').is(':checked') ?? false) as boolean;
+
+  const filtered = allGames.filter((g) => {
+    if (query && !matchesQuery(g, query)) return false;
+    if (decisiveOnly && !isDecisive(g.result)) return false;
+    return true;
+  });
+
   const $container = $('#games-container');
   $container.empty();
   $container.append(renderGames(filtered));
@@ -152,6 +163,7 @@ function autoLoadLatest() {
 
 export function init() {
   $('#games-filter-input').on('input', applyFilter);
+  $('#games-filter-decisive').on('change', applyFilter);
 
   on('tab:change', ({ tab }) => {
     if (tab === 'games') fetchAndRender();

--- a/views/partials/chat.ejs
+++ b/views/partials/chat.ejs
@@ -62,6 +62,7 @@
   <div id="games-tab-panel" class="tab-panel">
     <div class="games-filter">
       <input id="games-filter-input" type="search" placeholder="Filter by player..." autocomplete="off" />
+      <label class="games-filter-decisive"><input id="games-filter-decisive" type="checkbox" /> Decisive only</label>
     </div>
     <div class="card fluid" id="games-container"></div>
   </div>


### PR DESCRIPTION
Adds a "Decisive only" checkbox to the far right of the Games tab filter bar, restricting the list to non-draw games (1-0 / 0-1).

- `views/partials/chat.ejs`: render the checkbox next to the filter input
- `public/css/_games.scss`: filter row becomes flex (input flexes, checkbox pinned right)
- `public/js/components/games/index.ts`: `isDecisive` helper, filter composes player + decisive conditions, checkbox bound in init
- `.gitignore`: ignore `.playwright-mcp/` and `dogfood-output/`

Dogfooded against the live 16064 broadcast: 195 games -> 13 decisive-only; player+decisive combo works.