### PR TITLE
refactor(ui): centralize board sizing, css vars, and games fetch

### DIFF
--- a/public/js/components/board/arrows.ts
+++ b/public/js/components/board/arrows.ts
@@ -92,3 +92,8 @@ export function clearArrows() {
   if (ctx === null) return;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 }
+
+export function sizeArrowBoard() {
+  const b = $('#board');
+  $('#arrow-board').attr('height', b.height()!).height(b.height()!).attr('width', b.width()!).width(b.width()!);
+}

--- a/public/js/components/board/index.ts
+++ b/public/js/components/board/index.ts
@@ -6,9 +6,10 @@ import type { SerializedGame, ColorCode } from '../../../../shared/types';
 import { colorName } from '../../../../shared/colors';
 import { on } from '../../events/index';
 import type { GameEventData, NavPosition } from '../../events/index';
-import { drawMove, clearArrows } from './arrows';
+import { drawMove, clearArrows, sizeArrowBoard } from './arrows';
 import { initResize } from './resize';
 import copyFen from '../../utils/fen';
+import { getCssVar } from '../../utils/dom';
 import { isReplayMode } from '../replay/index';
 import { getPieceSet } from '../theme/index';
 import { pieceSrc } from '../theme/piece-sets';
@@ -27,12 +28,6 @@ let navMoveColor: ColorCode | null = null;
 let navFen = '';
 
 const EMPTY_FEN = '8/8/8/8/8/8/8/8';
-
-// Arrow colors are theme tokens (see theme/presets.ts) so they follow the active
-// palette and any custom overrides. Read live at draw time, falling back to the
-// light-preset value if the token is unset (e.g. read before the theme applies).
-const getCssVar = (name: string, fallback: string): string =>
-  getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
 
 function updatePvBoards(fens: { white: string; black: string }) {
   pvBoardWhite!.position(fens.white, false);
@@ -259,8 +254,7 @@ export function init() {
 
   // Initialize arrow canvas
   clearArrows();
-  const b = $('#board');
-  $('#arrow-board').attr('height', b.height()!).height(b.height()!).attr('width', b.width()!).width(b.width()!);
+  sizeArrowBoard();
 
   // Initialize PV boards
   const pvBoardSettings = {
@@ -297,8 +291,7 @@ export function init() {
 export function resize() {
   if (board) board.resize();
 
-  const b = $('#board');
-  $('#arrow-board').attr('height', b.height()!).height(b.height()!).attr('width', b.width()!).width(b.width()!);
+  sizeArrowBoard();
   drawArrows();
 }
 

--- a/public/js/components/board/resize.ts
+++ b/public/js/components/board/resize.ts
@@ -2,6 +2,7 @@
 import $ from 'jquery';
 import type { ChessboardInstance } from 'chessboardjs';
 import { emit } from '../../events/index';
+import { sizeArrowBoard } from './arrows';
 
 const INFO_CARD_HEIGHT = 155;
 const GAP = 32;
@@ -65,8 +66,7 @@ export function initResize(
     pvBoardWhite.resize();
     pvBoardBlack.resize();
 
-    const b = $('#board');
-    $('#arrow-board').attr('height', b.height()!).height(b.height()!).attr('width', b.width()!).width(b.width()!);
+    sizeArrowBoard();
     emit('board:resize', undefined);
   }
 

--- a/public/js/components/games/index.ts
+++ b/public/js/components/games/index.ts
@@ -115,7 +115,7 @@ function loadReplay(gameNumber: number) {
 
 function applyFilter() {
   const query = String($('#games-filter-input').val() ?? '');
-  const decisiveOnly = ($('#games-filter-decisive').is(':checked') ?? false) as boolean;
+  const decisiveOnly = $('#games-filter-decisive').is(':checked');
 
   const filtered = allGames.filter((g) => {
     if (query && !matchesQuery(g, query)) return false;
@@ -128,7 +128,7 @@ function applyFilter() {
   $container.append(renderGames(filtered));
 }
 
-function fetchAndRender() {
+function fetchAndRender(onData?: (data: GameRecord[]) => void) {
   const $container = $('#games-container');
   $container.html('<p class="games-loading">Loading games...</p>');
 
@@ -140,6 +140,7 @@ function fetchAndRender() {
     .done((data: GameRecord[]) => {
       allGames = data;
       applyFilter();
+      onData?.(data);
     })
     .fail(() => {
       $container.html('<p class="games-error">No games available.</p>');
@@ -148,17 +149,11 @@ function fetchAndRender() {
 
 // Archive pages have no live feed, so open them on the most recent finished game
 // (highest game number with a saved meta sidecar) to avoid landing on a blank board.
-function autoLoadLatest() {
-  $.ajax({
-    url: `${apiBase()}/games/json`,
-    method: 'GET',
-    dataType: 'json',
-  }).done((data: GameRecord[]) => {
-    const latest = data
-      .filter((g) => g.metaUrl)
-      .reduce<GameRecord | null>((best, g) => (!best || g.gameNumber > best.gameNumber ? g : best), null);
-    if (latest) loadReplay(latest.gameNumber);
-  });
+function loadLatest(fetchData: GameRecord[]) {
+  const latest = fetchData
+    .filter((g) => g.metaUrl)
+    .reduce<GameRecord | null>((best, g) => (!best || g.gameNumber > best.gameNumber ? g : best), null);
+  if (latest) loadReplay(latest.gameNumber);
 }
 
 export function init() {
@@ -170,7 +165,6 @@ export function init() {
   });
 
   if (isArchive()) {
-    fetchAndRender();
-    autoLoadLatest();
+    fetchAndRender(loadLatest);
   }
 }

--- a/public/js/components/graphs/index.ts
+++ b/public/js/components/graphs/index.ts
@@ -16,6 +16,7 @@ import { goTo, getNavIndex } from '../navigation/index';
 import GRAPH_TYPES from './graph-types';
 import { init as initSelector, setActive } from './selector';
 import { isReplayMode } from '../replay/index';
+import { getCssVar } from '../../utils/dom';
 
 Chart.register(LineController, LineElement, PointElement, LinearScale, CategoryScale, Tooltip, Legend);
 
@@ -27,10 +28,6 @@ let gameMoves: MoveMetaData[] = [];
 let whiteName = '';
 let blackName = '';
 let kibitzerName = '';
-
-function getCssVar(name: string) {
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-}
 
 function buildPointRadii(dataArray: (number | null)[]) {
   const activeIdx = getNavIndex() - 1;

--- a/public/js/utils/dom.ts
+++ b/public/js/utils/dom.ts
@@ -1,0 +1,3 @@
+export function getCssVar(name: string, fallback = ''): string {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+}


### PR DESCRIPTION
## Summary

Cleanup pass over the frontend UI codebase. No behavior change — deduplicates and centralizes shared logic.

## Changes

- **Arrow-board sizing** — the identical `$('#arrow-board').attr('height', b.height()!)…` expression was copy-pasted into `board/index.ts` (init + resize) and `board/resize.ts`. Extracted into `sizeArrowBoard()` in `board/arrows.ts`.
- **CSS variable reads** — two separate `getCssVar` helpers (`board/index.ts` with fallback, `graphs/index.ts` without). Unified into a shared `public/js/utils/dom.ts` with a default fallback.
- **Games fetch** — on archive pages, `fetchAndRender()` and `autoLoadLatest()` both fetched `/games/json`. Combined into one fetch via an `onData` callback (`public/js/components/games/index.ts`).
- **Quality** — dropped a redundant `?? false` cast on a never-null jQuery boolean.

## Verification

- `npm run build` (webpack + backend tsc) passes
- `npx tsc -p tsconfig.frontend.json` passes
- `npm run lint` passes
- Dogfooded against live broadcast 16064: arrow canvas stays in sync with board (incl. resize), theme switching / graph rendering use the unified getCssVar with no console errors, games decisive-only filter works.