### PR TITLE
refactor: simplify backend core

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -10,17 +10,5 @@
     "GrahamCCRL.dyndns.org:16070",
     "GrahamCCRL.dyndns.org:16072",
     "GrahamCCRL.dyndns.org:16073"
-  ],
-  "connectionHistory": [
-    "GrahamCCRL.dyndns.org:16061",
-    "GrahamCCRL.dyndns.org:16062",
-    "GrahamCCRL.dyndns.org:16063",
-    "GrahamCCRL.dyndns.org:16064",
-    "GrahamCCRL.dyndns.org:16065",
-    "GrahamCCRL.dyndns.org:16066",
-    "GrahamCCRL.dyndns.org:16067",
-    "GrahamCCRL.dyndns.org:16070",
-    "GrahamCCRL.dyndns.org:16072",
-    "GrahamCCRL.dyndns.org:16073"
   ]
 }

--- a/config/config.json
+++ b/config/config.json
@@ -10,5 +10,17 @@
     "GrahamCCRL.dyndns.org:16070",
     "GrahamCCRL.dyndns.org:16072",
     "GrahamCCRL.dyndns.org:16073"
+  ],
+  "connectionHistory": [
+    "GrahamCCRL.dyndns.org:16061",
+    "GrahamCCRL.dyndns.org:16062",
+    "GrahamCCRL.dyndns.org:16063",
+    "GrahamCCRL.dyndns.org:16064",
+    "GrahamCCRL.dyndns.org:16065",
+    "GrahamCCRL.dyndns.org:16066",
+    "GrahamCCRL.dyndns.org:16067",
+    "GrahamCCRL.dyndns.org:16070",
+    "GrahamCCRL.dyndns.org:16072",
+    "GrahamCCRL.dyndns.org:16073"
   ]
 }

--- a/src/broadcast-state.ts
+++ b/src/broadcast-state.ts
@@ -21,38 +21,21 @@ export class BroadcastState {
     this.browserCount = 0;
   }
 
-  addChat(message: string): void {
-    this.chat.push(message);
-  }
-
-  addSpectator(name: string): void {
-    this.spectators.add(name);
-  }
-
-  removeSpectator(name: string): boolean {
-    return this.spectators.delete(name);
-  }
-
-  hasSpectator(name: string): boolean {
-    return this.spectators.has(name);
-  }
-
-  setMenu(name: string, url: string): void {
-    this.menu.set(name, url);
-  }
-
   toJSON(includeChat = false): {
     spectators: Array<string>;
     chat: Array<string>;
     menu: { [key: string]: string };
   } {
-    const menu: { [key: string]: string } = {};
-    for (const e of this.menu.entries()) menu[e[0]] = e[1];
-
     return {
       spectators: Array.from(this.spectators),
       chat: includeChat ? this.chat.slice(-1000) : [],
-      menu,
+      menu: menuToObject(this.menu),
     };
   }
+}
+
+export function menuToObject(menu: Map<string, string>): { [key: string]: string } {
+  const obj: { [key: string]: string } = {};
+  for (const e of menu.entries()) obj[e[0]] = e[1];
+  return obj;
 }

--- a/src/game-service.ts
+++ b/src/game-service.ts
@@ -18,6 +18,8 @@ import { Command, splitOnCommand } from './protocol.js';
 import { EmitType } from './socket-io-adapter.js';
 import { commandsProcessed, chatMessages } from './metrics.js';
 import { parseResults, parseGames, mergeGames } from './services/result-parser.js';
+import { menuToObject } from './broadcast-state.js';
+import { replayUci } from './util/uci.js';
 import type { BroadcastDelta, ColorCode, GameDelta, MoveMetaData } from '../shared/types.js';
 
 type Color = 'white' | 'black';
@@ -30,7 +32,6 @@ type UpdateResult = [EmitType, boolean, ...Array<any>];
 type ConfigItem = {
   fn: (tokens: CommandTokens) => Promise<UpdateResult> | UpdateResult;
   split: boolean;
-  lowPrio: boolean;
 };
 
 type CommandConfig = {
@@ -100,30 +101,30 @@ class GameService {
     this.game = this.broadcast.game;
 
     this.commandConfig = {
-      [Command.FEN]: { fn: this.onFen.bind(this), split: true, lowPrio: false },
-      [Command.WPLAYER]: { fn: this.onPlayer.bind(this), split: false, lowPrio: false },
-      [Command.BPLAYER]: { fn: this.onPlayer.bind(this), split: false, lowPrio: false },
-      [Command.WPV]: { fn: this.onPV.bind(this), split: true, lowPrio: false },
-      [Command.BPV]: { fn: this.onPV.bind(this), split: true, lowPrio: false },
-      [Command.WTIME]: { fn: this.onTime.bind(this), split: true, lowPrio: false },
-      [Command.BTIME]: { fn: this.onTime.bind(this), split: true, lowPrio: false },
-      [Command.WMOVE]: { fn: this.onMove.bind(this), split: true, lowPrio: false },
-      [Command.BMOVE]: { fn: this.onMove.bind(this), split: true, lowPrio: false },
-      [Command.SITE]: { fn: this.onSite.bind(this), split: false, lowPrio: false },
-      [Command.CTRESET]: { fn: this.onCTReset.bind(this), split: false, lowPrio: false },
-      [Command.CT]: { fn: this.onCT.bind(this), split: false, lowPrio: false },
-      [Command.PONG]: { fn: () => [EmitType.UPDATE, false], split: false, lowPrio: false },
-      [Command.ADDUSER]: { fn: this.onAddUser.bind(this), split: false, lowPrio: false },
-      [Command.DELUSER]: { fn: this.onDelUser.bind(this), split: false, lowPrio: false },
-      [Command.CHAT]: { fn: this.onChat.bind(this), split: false, lowPrio: false },
-      [Command.MENU]: { fn: this.onMenu.bind(this), split: true, lowPrio: false },
-      [Command.RESULT]: { fn: this.onResult.bind(this), split: false, lowPrio: false },
-      [Command.FMR]: { fn: this.onFmr.bind(this), split: false, lowPrio: false },
+      [Command.FEN]: { fn: this.onFen.bind(this), split: true },
+      [Command.WPLAYER]: { fn: this.onPlayer.bind(this), split: false },
+      [Command.BPLAYER]: { fn: this.onPlayer.bind(this), split: false },
+      [Command.WPV]: { fn: this.onPV.bind(this), split: true },
+      [Command.BPV]: { fn: this.onPV.bind(this), split: true },
+      [Command.WTIME]: { fn: this.onTime.bind(this), split: true },
+      [Command.BTIME]: { fn: this.onTime.bind(this), split: true },
+      [Command.WMOVE]: { fn: this.onMove.bind(this), split: true },
+      [Command.BMOVE]: { fn: this.onMove.bind(this), split: true },
+      [Command.SITE]: { fn: this.onSite.bind(this), split: false },
+      [Command.CTRESET]: { fn: this.onCTReset.bind(this), split: false },
+      [Command.CT]: { fn: this.onCT.bind(this), split: false },
+      [Command.PONG]: { fn: () => [EmitType.UPDATE, false], split: false },
+      [Command.ADDUSER]: { fn: this.onAddUser.bind(this), split: false },
+      [Command.DELUSER]: { fn: this.onDelUser.bind(this), split: false },
+      [Command.CHAT]: { fn: this.onChat.bind(this), split: false },
+      [Command.MENU]: { fn: this.onMenu.bind(this), split: true },
+      [Command.RESULT]: { fn: this.onResult.bind(this), split: false },
+      [Command.FMR]: { fn: this.onFmr.bind(this), split: false },
       // Recognized but intentionally ignored — connection-time handshake/config
       // lines the viewer derives nothing from (see docs/protocol.md "No-op protocol commands").
-      [Command.LOGON]: { fn: () => [EmitType.UPDATE, false], split: false, lowPrio: false },
-      [Command.FEATURE]: { fn: () => [EmitType.UPDATE, false], split: false, lowPrio: false },
-      [Command.LEVEL]: { fn: () => [EmitType.UPDATE, false], split: false, lowPrio: false },
+      [Command.LOGON]: { fn: () => [EmitType.UPDATE, false], split: false },
+      [Command.FEATURE]: { fn: () => [EmitType.UPDATE, false], split: false },
+      [Command.LEVEL]: { fn: () => [EmitType.UPDATE, false], split: false },
     };
   }
 
@@ -207,28 +208,8 @@ class GameService {
     return [EmitType.UPDATE, false];
   }
 
-  private replayPV(chess: Chess, pv: string[]): { san: string[]; alg: string[]; fen: string } | null {
-    const san: string[] = [];
-    const alg: string[] = [];
-
-    for (const move of pv) {
-      try {
-        const result = chess.move(move, { strict: false });
-        san.push(result.san);
-        alg.push(`${result.from}${result.to}`);
-      } catch {
-        break;
-      }
-    }
-
-    return san.length ? { san, alg, fen: chess.fen() } : null;
-  }
-
   private playoutPV(pv: string[]): { san: string[]; alg: string[]; fen: string } | null {
-    const pvPlayout = new Chess();
-    pvPlayout.loadPgn(this.game.instance.pgn());
-
-    return this.replayPV(pvPlayout, pv);
+    return replayUci(new Chess(this.game.instance.fen()), pv);
   }
 
   // WPV/BPV payloads are positional: depth score time nodes pv...
@@ -278,7 +259,7 @@ class GameService {
 
     // The trailing PV describes the search that produced the move just played, so it
     // replays from the position that move was made from.
-    const playout = this.replayPV(new Chess(this.fenBeforeLastMove), pv);
+    const playout = replayUci(new Chess(this.fenBeforeLastMove), pv);
     // The PV must open with the move actually played; otherwise it belongs to a
     // different position and must not overwrite this move's meta.
     if (!playout || playout.san[0] !== lastMove.move) return;
@@ -544,8 +525,16 @@ class GameService {
     // Disable connection messages. TODO: Make this configurable
     if (tokens[1].endsWith('has arrived!') || tokens[1].endsWith('has left!')) return [EmitType.CHAT, false];
 
-    this.broadcast.chat.push(tokens[1]);
+    this.pushChat(tokens[1]);
     return [EmitType.CHAT, true, tokens[1]];
+  }
+
+  // Bound the retained chat buffer (toJSON only trims the emitted tail).
+  private pushChat(message: string): void {
+    if (this.broadcast.chat.length >= 2000) {
+      this.broadcast.chat.splice(0, this.broadcast.chat.length - 1999);
+    }
+    this.broadcast.chat.push(message);
   }
 
   private onMenu(tokens: CommandTokens): UpdateResult {
@@ -576,7 +565,7 @@ class GameService {
     const message = `[Server] - Game ${this.broadcast.currentGameNumber}: ${this.game.white.name} - ${
       this.game.black.name
     } (${tokens[1].trim()})`;
-    this.broadcast.chat.push(message);
+    this.pushChat(message);
 
     const result = tokens[1].trim();
     this.game.instance.header('Result', result);
@@ -675,34 +664,26 @@ class GameService {
     }
 
     if (d.menu) {
-      const menu: { [key: string]: string } = {};
-      for (const e of this.broadcast.menu.entries()) menu[e[0]] = e[1];
-      delta.menu = menu;
+      delta.menu = menuToObject(this.broadcast.menu);
     }
 
     return delta;
   }
 
-  private categorizeMessages(messages: string[]): { highPrio: [Command, string][]; lowPrio: Map<Command, string> } {
-    const highPrio: [Command, string][] = [];
-    const lowPrio = new Map<Command, string>();
+  private categorizeMessages(messages: string[]): [Command, string][] {
+    const ready: [Command, string][] = [];
 
     for (const msg of messages) {
       const [cmd, rest] = splitOnCommand(msg);
-      const config = this.commandConfig[cmd] as ConfigItem | undefined;
-      if (!config) {
+      if (!this.commandConfig[cmd]) {
         logger.warn(`Unable to process ${cmd}!`, { port: this.broadcast.port });
         continue;
       }
 
-      if (config.lowPrio) {
-        lowPrio.set(cmd, rest);
-      } else {
-        highPrio.push([cmd, rest]);
-      }
+      ready.push([cmd, rest]);
     }
 
-    return { highPrio, lowPrio };
+    return ready;
   }
 
   async onMessages(messages: string[]): Promise<GameServiceResult> {
@@ -711,15 +692,7 @@ class GameService {
     this.patchedMoves.clear();
     const chatEmit: string[] = [];
 
-    const processLowPrio = this.broadcast.browserCount > 0;
-    if (!processLowPrio)
-      logger.info('No one viewing broadcast, skipping processing of low-priority messages.', {
-        port: this.broadcast.port,
-      });
-
-    const { highPrio, lowPrio } = this.categorizeMessages(messages);
-
-    for (const [cmd, rest] of [...highPrio, ...(processLowPrio ? lowPrio : [])]) {
+    for (const [cmd, rest] of this.categorizeMessages(messages)) {
       const commandConfig = this.commandConfig[cmd];
 
       const [emit, updated, ...updateData] = await commandConfig.fn(

--- a/src/kibitzer/kibitzer-manager.ts
+++ b/src/kibitzer/kibitzer-manager.ts
@@ -3,6 +3,7 @@ import broadcasts from '../broadcast.js';
 import { emitUpdate } from '../socket-io-adapter.js';
 import { kibitzerAssignments } from '../metrics.js';
 import { logger } from '../util/index.js';
+import { replayUci } from '../util/uci.js';
 import { createTransport } from './transport-factory.js';
 import type { KibitzerTransport, KibitzerConfig, AnalysisInfo } from './types.js';
 import type { ColorCode, KibitzerMeta, SerializedKibitzerLiveData } from '../../shared/types.js';
@@ -132,7 +133,7 @@ export class KibitzerManager {
         id: entry.id,
         type: entry.config.type,
         priority: entry.config.priority,
-        enginePath: entry.config.type === 'ssh' ? entry.config.enginePath : entry.config.enginePath ?? 'stockfish',
+        enginePath: entry.config.enginePath ?? 'stockfish',
         threads: entry.config.threads ?? 1,
         hash: entry.config.hash ?? 256,
         ready: entry.transport.ready,
@@ -197,23 +198,6 @@ export class KibitzerManager {
       pvMoveNumber: pv?.moveNumber ?? 1,
       name: slot.transport.name(),
     };
-  }
-
-  getTargetPort(): number | null {
-    let best: number | null = null;
-    let bestCount = 0;
-    for (const port of this.slots.keys()) {
-      const bc = broadcasts.get(port);
-      if (bc && bc.browserCount > bestCount) {
-        bestCount = bc.browserCount;
-        best = port;
-      }
-    }
-    return best;
-  }
-
-  isTargeted(port: number): boolean {
-    return this.slots.has(port);
   }
 
   private emitKibitzerUpdates(): void {
@@ -303,20 +287,8 @@ export class KibitzerManager {
     try {
       const chess = new Chess(fen);
       const moveNumber = chess.moveNumber();
-      const san: string[] = [];
-      const alg: string[] = [];
-
-      for (const move of uciMoves) {
-        try {
-          const result = chess.move(move, { strict: false });
-          san.push(result.san);
-          alg.push(`${result.from}${result.to}`);
-        } catch {
-          break;
-        }
-      }
-
-      return san.length ? { san, alg, fen: chess.fen(), moveNumber } : null;
+      const replay = replayUci(chess, uciMoves);
+      return replay ? { ...replay, moveNumber } : null;
     } catch {
       return null;
     }

--- a/src/kibitzer/local-transport.ts
+++ b/src/kibitzer/local-transport.ts
@@ -2,32 +2,16 @@ import { spawn } from 'child_process';
 import type { ChildProcessWithoutNullStreams } from 'child_process';
 import { createInterface } from 'readline';
 import { logger } from '../util/index.js';
-import { parseInfoLine } from './uci-parser.js';
-import type { AnalysisInfo } from './uci-parser.js';
-import type { KibitzerTransport, LocalKibitzerConfig } from './types.js';
+import { UciTransportBase } from './uci-transport-base.js';
+import type { LocalKibitzerConfig } from './types.js';
 
-export class LocalTransport implements KibitzerTransport {
+export class LocalTransport extends UciTransportBase {
   private proc: ChildProcessWithoutNullStreams | null = null;
-  private callback: ((info: AnalysisInfo) => void) | null = null;
-  private _ready = false;
-
-  get ready(): boolean {
-    return this._ready;
-  }
-
-  private stm: 'w' | 'b' = 'w';
-  private pendingFen: string | null = null;
-  private engineName: string;
-
   private readonly enginePath: string;
-  private readonly threads: number;
-  private readonly hash: number;
 
   constructor(config: LocalKibitzerConfig) {
+    super({ threads: config.threads, hash: config.hash }, 'Stockfish');
     this.enginePath = config.enginePath ?? 'stockfish';
-    this.threads = config.threads ?? 1;
-    this.hash = config.hash ?? 256;
-    this.engineName = 'Stockfish';
   }
 
   create(): void {
@@ -54,9 +38,7 @@ export class LocalTransport implements KibitzerTransport {
   }
 
   teardown(): void {
-    this._ready = false;
-    this.callback = null;
-    this.pendingFen = null;
+    this.clearState();
     if (this.proc) {
       this.send('quit');
       setTimeout(() => {
@@ -68,68 +50,9 @@ export class LocalTransport implements KibitzerTransport {
     }
   }
 
-  startAnalysis(fen: string): void {
-    if (!this.proc) return;
-
-    const parts = fen.split(' ');
-    this.stm = (parts[1] ?? 'w') as 'w' | 'b';
-
-    if (!this._ready) {
-      this.pendingFen = fen;
-      return;
-    }
-
-    this.send('stop');
-    this.send(`position fen ${fen}`);
-    this.send('go infinite');
-  }
-
-  stopAnalysis(): void {
-    this.pendingFen = null;
-    this.send('stop');
-  }
-
-  onAnalysis(callback: (info: AnalysisInfo) => void): void {
-    this.callback = callback;
-  }
-
-  name(): string {
-    return this.engineName;
-  }
-
-  private send(cmd: string): void {
+  protected send(cmd: string): void {
     if (this.proc?.stdin.writable) {
       this.proc.stdin.write(`${cmd}\n`);
-    }
-  }
-
-  private onLine(line: string): void {
-    if (line.startsWith('id name ')) {
-      this.engineName = line.slice('id name '.length);
-      return;
-    }
-
-    if (line === 'uciok') {
-      this.send(`setoption name Threads value ${this.threads}`);
-      this.send(`setoption name Hash value ${this.hash}`);
-      this.send('isready');
-      return;
-    }
-
-    if (line === 'readyok') {
-      this._ready = true;
-      logger.info(`Kibitzer engine ready (Threads=${this.threads}, Hash=${this.hash})`);
-      if (this.pendingFen) {
-        const fen = this.pendingFen;
-        this.pendingFen = null;
-        this.startAnalysis(fen);
-      }
-      return;
-    }
-
-    if (line.startsWith('info ') && this.callback) {
-      const info = parseInfoLine(line, this.stm);
-      if (info) this.callback(info);
     }
   }
 }

--- a/src/kibitzer/ssh-transport.ts
+++ b/src/kibitzer/ssh-transport.ts
@@ -3,31 +3,17 @@ import type { ClientChannel } from 'ssh2';
 import fs from 'node:fs';
 import { createInterface } from 'readline';
 import { logger } from '../util/index.js';
-import { parseInfoLine } from './uci-parser.js';
-import type { AnalysisInfo } from './uci-parser.js';
-import type { KibitzerTransport, SshKibitzerConfig } from './types.js';
+import { UciTransportBase } from './uci-transport-base.js';
+import type { SshKibitzerConfig } from './types.js';
 
-export class SshTransport implements KibitzerTransport {
+export class SshTransport extends UciTransportBase {
   private client: Client | null = null;
   private channel: ClientChannel | null = null;
-  private callback: ((info: AnalysisInfo) => void) | null = null;
-  private _ready = false;
+  private readonly config: SshKibitzerConfig;
 
-  get ready(): boolean {
-    return this._ready;
-  }
-
-  private stm: 'w' | 'b' = 'w';
-  private pendingFen: string | null = null;
-  private engineName: string;
-
-  private readonly threads: number;
-  private readonly hash: number;
-
-  constructor(private readonly config: SshKibitzerConfig) {
-    this.threads = config.threads ?? 1;
-    this.hash = config.hash ?? 256;
-    this.engineName = `Remote Engine @ ${config.host}`;
+  constructor(config: SshKibitzerConfig) {
+    super({ threads: config.threads, hash: config.hash }, `Remote Engine @ ${config.host}`);
+    this.config = config;
   }
 
   create(): void {
@@ -93,9 +79,7 @@ export class SshTransport implements KibitzerTransport {
   }
 
   teardown(): void {
-    this._ready = false;
-    this.callback = null;
-    this.pendingFen = null;
+    this.clearState();
     this.send('quit');
     setTimeout(() => {
       if (this.channel) {
@@ -109,68 +93,9 @@ export class SshTransport implements KibitzerTransport {
     }, 1000);
   }
 
-  startAnalysis(fen: string): void {
-    if (!this.channel) return;
-
-    const parts = fen.split(' ');
-    this.stm = (parts[1] ?? 'w') as 'w' | 'b';
-
-    if (!this._ready) {
-      this.pendingFen = fen;
-      return;
-    }
-
-    this.send('stop');
-    this.send(`position fen ${fen}`);
-    this.send('go infinite');
-  }
-
-  stopAnalysis(): void {
-    this.pendingFen = null;
-    this.send('stop');
-  }
-
-  onAnalysis(callback: (info: AnalysisInfo) => void): void {
-    this.callback = callback;
-  }
-
-  name(): string {
-    return this.engineName;
-  }
-
-  private send(cmd: string): void {
+  protected send(cmd: string): void {
     if (this.channel?.writable) {
       this.channel.write(`${cmd}\n`);
-    }
-  }
-
-  private onLine(line: string): void {
-    if (line.startsWith('id name ')) {
-      this.engineName = line.slice('id name '.length);
-      return;
-    }
-
-    if (line === 'uciok') {
-      this.send(`setoption name Threads value ${this.threads}`);
-      this.send(`setoption name Hash value ${this.hash}`);
-      this.send('isready');
-      return;
-    }
-
-    if (line === 'readyok') {
-      this._ready = true;
-      logger.info(`Kibitzer SSH engine ready on ${this.config.host} (Threads=${this.threads}, Hash=${this.hash})`);
-      if (this.pendingFen) {
-        const fen = this.pendingFen;
-        this.pendingFen = null;
-        this.startAnalysis(fen);
-      }
-      return;
-    }
-
-    if (line.startsWith('info ') && this.callback) {
-      const info = parseInfoLine(line, this.stm);
-      if (info) this.callback(info);
     }
   }
 }

--- a/src/kibitzer/uci-transport-base.ts
+++ b/src/kibitzer/uci-transport-base.ts
@@ -1,0 +1,95 @@
+import { logger } from '../util/index.js';
+import { parseInfoLine } from './uci-parser.js';
+import type { AnalysisInfo } from './uci-parser.js';
+import type { KibitzerTransport } from './types.js';
+
+// Shared UCI engine state machine — handshake, option setup, pending-position replay
+// and the info-line callback — used by both the local and SSH transports, which only
+// differ in how they spawn/connect and write a command to the raw stream.
+export abstract class UciTransportBase implements KibitzerTransport {
+  protected callback: ((info: AnalysisInfo) => void) | null = null;
+  protected _ready = false;
+  protected stm: 'w' | 'b' = 'w';
+  protected pendingFen: string | null = null;
+  protected engineName: string;
+
+  protected readonly threads: number;
+  protected readonly hash: number;
+
+  constructor(options: { threads?: number; hash?: number }, defaultName: string) {
+    this.threads = options.threads ?? 1;
+    this.hash = options.hash ?? 256;
+    this.engineName = defaultName;
+  }
+
+  get ready(): boolean {
+    return this._ready;
+  }
+
+  abstract create(): void;
+  abstract teardown(): void;
+  protected abstract send(cmd: string): void;
+
+  startAnalysis(fen: string): void {
+    const parts = fen.split(' ');
+    this.stm = (parts[1] ?? 'w') as 'w' | 'b';
+
+    if (!this._ready) {
+      this.pendingFen = fen;
+      return;
+    }
+
+    this.send('stop');
+    this.send(`position fen ${fen}`);
+    this.send('go infinite');
+  }
+
+  stopAnalysis(): void {
+    this.pendingFen = null;
+    this.send('stop');
+  }
+
+  onAnalysis(callback: (info: AnalysisInfo) => void): void {
+    this.callback = callback;
+  }
+
+  name(): string {
+    return this.engineName;
+  }
+
+  protected onLine(line: string): void {
+    if (line.startsWith('id name ')) {
+      this.engineName = line.slice('id name '.length);
+      return;
+    }
+
+    if (line === 'uciok') {
+      this.send(`setoption name Threads value ${this.threads}`);
+      this.send(`setoption name Hash value ${this.hash}`);
+      this.send('isready');
+      return;
+    }
+
+    if (line === 'readyok') {
+      this._ready = true;
+      logger.info(`Kibitzer engine ready (Threads=${this.threads}, Hash=${this.hash})`);
+      if (this.pendingFen) {
+        const fen = this.pendingFen;
+        this.pendingFen = null;
+        this.startAnalysis(fen);
+      }
+      return;
+    }
+
+    if (line.startsWith('info ') && this.callback) {
+      const info = parseInfoLine(line, this.stm);
+      if (info) this.callback(info);
+    }
+  }
+
+  protected clearState(): void {
+    this._ready = false;
+    this.callback = null;
+    this.pendingFen = null;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
 import 'dotenv/config';
 
-import crypto from 'node:crypto';
 import http from 'http';
 import { app } from './app.js';
 import { io } from './socket-io-adapter.js';
 import { logger } from './util/index.js';
+import { genId } from './util/ids.js';
 import { connect, setKibitzerManager, setWebhookManager } from './broadcast-manager.js';
 import { KibitzerManager } from './kibitzer/index.js';
 import { WebhookManager } from './webhooks/index.js';
@@ -29,13 +29,13 @@ io.attach(server);
   let needsSave = false;
   for (const k of kibitzers) {
     if (!k.id) {
-      k.id = crypto.randomUUID().slice(0, 8);
+      k.id = genId();
       needsSave = true;
     }
   }
   for (const w of webhooks) {
     if (!w.id) {
-      w.id = crypto.randomUUID().slice(0, 8);
+      w.id = genId();
       needsSave = true;
     }
   }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,8 +1,8 @@
-import crypto from 'node:crypto';
 import { Router, Request, Response } from 'express';
 import basic from 'express-basic-auth';
 import broadcasts from '../broadcast.js';
 import { logger } from '../util/index.js';
+import { genId } from '../util/ids.js';
 import { closeConnection, getKibitzerManager, getWebhookManager, newConnection } from '../broadcast-manager.js';
 import configStore from '../config/config-store.js';
 import type { KibitzerConfig } from '../kibitzer/types.js';
@@ -63,7 +63,7 @@ router.post('/kibitzers', async (req: Request, res: Response) => {
   const body = req.body;
 
   try {
-    const id = crypto.randomUUID().slice(0, 8);
+    const id = genId();
     let config: KibitzerConfig;
 
     if (body.type === 'ssh') {
@@ -132,7 +132,7 @@ router.post('/webhooks', async (req: Request, res: Response) => {
       return;
     }
 
-    const id = crypto.randomUUID().slice(0, 8);
+    const id = genId();
 
     const ports = String(body.ports ?? '')
       .split(',')

--- a/src/util/ids.ts
+++ b/src/util/ids.ts
@@ -1,0 +1,6 @@
+import crypto from 'node:crypto';
+
+// Short, collision-resistant ids for runtime-managed configs (kibitzers, webhooks).
+export function genId(): string {
+  return crypto.randomUUID().slice(0, 8);
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,6 +1,5 @@
 export { default as logger } from './logger.js';
 export { default as logging } from './logging.js';
 export { default as httpMetrics } from './http-metrics.js';
-export { splitOnCommand } from '../protocol.js';
 export { uniqueName } from './unique-name.js';
 export { siteSlug, gameFilenameSlug } from './slugs.js';

--- a/src/util/uci.ts
+++ b/src/util/uci.ts
@@ -1,0 +1,21 @@
+import type { Chess } from 'chess.js';
+
+// Replays a UCI principal-variation onto a copy-less live Chess instance, returning
+// null when no move in the PV could be played (stale/invalid line). Used by both the
+// game-service and the kibitzer manager to render PVs in SAN + coord/alg forms.
+export function replayUci(chess: Chess, pv: string[]): { san: string[]; alg: string[]; fen: string } | null {
+  const san: string[] = [];
+  const alg: string[] = [];
+
+  for (const move of pv) {
+    try {
+      const result = chess.move(move, { strict: false });
+      san.push(result.san);
+      alg.push(`${result.from}${result.to}`);
+    } catch {
+      break;
+    }
+  }
+
+  return san.length ? { san, alg, fen: chess.fen() } : null;
+}


### PR DESCRIPTION
## Summary

Cleanup pass over the backend (`src/`, `shared/`): deduplication, dead-code removal, and one hot-path win. Behavior-preserving — verified with `npm run build`, `eslint`, and a live run against Graham's TLCS broadcasts.

## Changes

**Reuse / dedup**
- New `src/util/uci.ts` `replayUci()` — shared UCI PV replay (SAN + coord/alg) previously duplicated in `game-service` and `kibitzer-manager`.
- New `src/kibitzer/uci-transport-base.ts` — extracts the duplicated UCI state machine (handshake, Threads/Hash setup, pending-FEN replay, `info` parsing) from `LocalTransport` / `SshTransport`, which now only own spawn/connect + `send()`.
- `menuToObject()` in `broadcast-state.ts` shared by `toJSON` and `buildDelta` (was duplicated byte-for-byte).
- New `src/util/ids.ts` `genId()` replaces 4× `crypto.randomUUID().slice(0, 8)` in `main.ts` + `routes/admin.ts`.

**Hot path**
- `playoutPV` replays PVs from the current FEN (`new Chess(game.fen())`) instead of regenerating + re-parsing the full PGN per PV message (this runs ~tens of times per move).

**Quality / dead code**
- Removed inert `lowPrio` message mechanism (every command was `false`; `categorizeMessages` never populated the low-priority bucket).
- Removed dead public methods: `getTargetPort()`/`isTargeted()` (kibitzer-manager), `addChat`/`addSpectator`/`removeSpectator`/`hasSpectator`/`setMenu` (broadcast-state), unused `splitOnCommand` re-export.
- Collapsed a no-op `ssh ? enginePath : enginePath ?? 'stockfish'` ternary.
- Bounded the retained chat buffer (was unbounded; serialization already trims to last 1000).

## Verification
- `npm run build` ✅ · `eslint` ✅ · `tsc --noEmit` ✅
- Ran locally against Graham's broadcasts (16061–16073) — confirmed streaming, moves/PV/tablebase/menu all processing with no errors.